### PR TITLE
Phase 7 W7: watching and async reimport, plus three W6 UI defects

### DIFF
--- a/RT2App/RT2App.vcxproj
+++ b/RT2App/RT2App.vcxproj
@@ -293,6 +293,7 @@ copy /Y "$(ProjectDir)shaders\picking.spv" "../bin/Dist-windows-x86_64/RT2App"</
     <ClInclude Include="src\ScriptFieldRegistry.h" />
     <ClInclude Include="src\ScriptFieldResolver.h" />
     <ClInclude Include="src\ScriptFieldValue.h" />
+    <ClInclude Include="src\AssetWatchPolicy.h" />
     <ClInclude Include="src\ScriptFileWatchPolicy.h" />
     <ClInclude Include="src\ScriptSandbox.h" />
     <ClInclude Include="src\ScriptScenarioCompare.h" />
@@ -674,6 +675,9 @@ copy /Y "$(ProjectDir)shaders\picking.spv" "../bin/Dist-windows-x86_64/RT2App"</
       <ExternalWarningLevel>Level3</ExternalWarningLevel>
     </ClCompile>
     <ClCompile Include="src\ContentBrowserOperations.cpp">
+      <ExternalWarningLevel>Level3</ExternalWarningLevel>
+    </ClCompile>
+    <ClCompile Include="src\AssetWatchPolicy.cpp">
       <ExternalWarningLevel>Level3</ExternalWarningLevel>
     </ClCompile>
     <ClCompile Include="src\SceneVisibility.cpp">

--- a/RT2App/src/AssetWatchPolicy.cpp
+++ b/RT2App/src/AssetWatchPolicy.cpp
@@ -1,0 +1,230 @@
+#include "AssetWatchPolicy.h"
+
+#include <algorithm>
+#include <cctype>
+#include <system_error>
+
+namespace rt2::core {
+namespace {
+
+std::string Fold(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(),
+        [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
+    return value;
+}
+
+AssetFileEventKind ClassifyExtension(const std::string& extension)
+{
+    if (extension == ".lua")
+        return AssetFileEventKind::ScriptReload;
+    if (extension == ".glb" || extension == ".gltf" ||
+        extension == ".obj" || extension == ".hdr" ||
+        extension == ".exr" || extension == ".rt2meta")
+        return AssetFileEventKind::DatabaseRefresh;
+    return AssetFileEventKind::Ignore;
+}
+
+AssetWatchEvent MakeEvent(const std::filesystem::path& path,
+                          AssetFileAction action)
+{
+    AssetWatchEvent event;
+    event.path = NormalizeWatchPath(path);
+    event.action = action;
+    event.kind = ClassifyAssetFileEvent(path, action);
+    event.refreshDatabase = AssetFileNeedsDatabaseRefresh(path, action);
+    return event;
+}
+
+} // namespace
+
+AssetFileEventKind ClassifyAssetFileEvent(
+    const std::filesystem::path& path,
+    AssetFileAction action)
+{
+    (void)action;
+    return ClassifyExtension(Fold(path.extension().u8string()));
+}
+
+bool AssetFileNeedsDatabaseRefresh(
+    const std::filesystem::path& path,
+    AssetFileAction action)
+{
+    const auto kind = ClassifyAssetFileEvent(path, action);
+    return kind == AssetFileEventKind::DatabaseRefresh ||
+           (kind == AssetFileEventKind::ScriptReload &&
+            action == AssetFileAction::Delete);
+}
+
+std::string NormalizeWatchPath(const std::filesystem::path& path)
+{
+    std::filesystem::path normalized = path;
+    if (!normalized.is_absolute())
+    {
+        std::error_code error;
+        normalized = std::filesystem::absolute(normalized, error);
+        if (error)
+            normalized = path;
+    }
+    return Fold(normalized.lexically_normal().u8string());
+}
+
+AssetWatchSuppressionRegistry::AssetWatchSuppressionRegistry(
+    std::mutex* sharedMutex)
+    : m_Mutex(sharedMutex ? sharedMutex : &m_OwnMutex)
+{
+}
+
+void AssetWatchSuppressionRegistry::Register(
+    const std::filesystem::path& path)
+{
+    std::lock_guard<std::mutex> lock(*m_Mutex);
+    RegisterLocked(path);
+}
+
+void AssetWatchSuppressionRegistry::RegisterMany(
+    const std::vector<std::filesystem::path>& paths)
+{
+    std::lock_guard<std::mutex> lock(*m_Mutex);
+    for (const auto& path : paths)
+        RegisterLocked(path);
+}
+
+bool AssetWatchSuppressionRegistry::IsSuppressed(
+    const std::filesystem::path& path) const
+{
+    std::lock_guard<std::mutex> lock(*m_Mutex);
+    return IsSuppressedLocked(path);
+}
+
+void AssetWatchSuppressionRegistry::Clear()
+{
+    std::lock_guard<std::mutex> lock(*m_Mutex);
+    ClearLocked();
+}
+
+size_t AssetWatchSuppressionRegistry::Size() const
+{
+    std::lock_guard<std::mutex> lock(*m_Mutex);
+    return SizeLocked();
+}
+
+void AssetWatchSuppressionRegistry::RegisterLocked(
+    const std::filesystem::path& path)
+{
+    const auto normalized = NormalizeWatchPath(path);
+    if (normalized.empty())
+        return;
+    if (std::find(m_Paths.begin(), m_Paths.end(), normalized) == m_Paths.end())
+        m_Paths.push_back(normalized);
+}
+
+bool AssetWatchSuppressionRegistry::IsSuppressedLocked(
+    const std::filesystem::path& path) const
+{
+    const auto normalized = NormalizeWatchPath(path);
+    return std::find(m_Paths.begin(), m_Paths.end(), normalized) != m_Paths.end();
+}
+
+void AssetWatchSuppressionRegistry::ClearLocked()
+{
+    m_Paths.clear();
+}
+
+size_t AssetWatchSuppressionRegistry::SizeLocked() const
+{
+    return m_Paths.size();
+}
+
+AssetWatchEventQueue::AssetWatchEventQueue(std::mutex* sharedMutex)
+    : m_Mutex(sharedMutex ? sharedMutex : &m_OwnMutex)
+{
+}
+
+bool AssetWatchEventQueue::Enqueue(const std::filesystem::path& path,
+                                   AssetFileAction action)
+{
+    std::lock_guard<std::mutex> lock(*m_Mutex);
+    return EnqueueLocked(path, action);
+}
+
+std::vector<AssetWatchEvent> AssetWatchEventQueue::Drain()
+{
+    std::lock_guard<std::mutex> lock(*m_Mutex);
+    return DrainLocked();
+}
+
+bool AssetWatchEventQueue::TakeOverflowed()
+{
+    std::lock_guard<std::mutex> lock(*m_Mutex);
+    return TakeOverflowedLocked();
+}
+
+size_t AssetWatchEventQueue::Size() const
+{
+    std::lock_guard<std::mutex> lock(*m_Mutex);
+    return SizeLocked();
+}
+
+bool AssetWatchEventQueue::EnqueueLocked(
+    const std::filesystem::path& path,
+    AssetFileAction action)
+{
+    const auto event = MakeEvent(path, action);
+    for (auto& existing : m_Events)
+    {
+        if (existing.path == event.path)
+        {
+            existing.action = event.action;
+            existing.kind = event.kind;
+            existing.refreshDatabase =
+                existing.refreshDatabase || event.refreshDatabase;
+            return true;
+        }
+    }
+
+    if (m_Events.size() >= kAssetWatchQueueLimit)
+    {
+        m_Events.erase(m_Events.begin());
+        m_Overflowed = true;
+    }
+    m_Events.push_back(event);
+    return true;
+}
+
+std::vector<AssetWatchEvent> AssetWatchEventQueue::DrainLocked()
+{
+    auto drained = std::move(m_Events);
+    m_Events.clear();
+    return drained;
+}
+
+bool AssetWatchEventQueue::TakeOverflowedLocked()
+{
+    const bool overflowed = m_Overflowed;
+    m_Overflowed = false;
+    return overflowed;
+}
+
+size_t AssetWatchEventQueue::SizeLocked() const
+{
+    return m_Events.size();
+}
+
+AssetWatchRefreshAction DecideWatchRefreshAction(
+    bool hasMissedEvents,
+    size_t queueSize,
+    bool backgroundBusy)
+{
+    if (backgroundBusy)
+        return queueSize >= kAssetWatchQueueLimit
+            ? AssetWatchRefreshAction::Truncate
+            : AssetWatchRefreshAction::Queue;
+    if (hasMissedEvents || queueSize > 0)
+        return AssetWatchRefreshAction::RefreshNow;
+    return AssetWatchRefreshAction::NoOp;
+}
+
+} // namespace rt2::core

--- a/RT2App/src/AssetWatchPolicy.cpp
+++ b/RT2App/src/AssetWatchPolicy.cpp
@@ -1,5 +1,7 @@
 #include "AssetWatchPolicy.h"
 
+#include "AssetIdentity.h"
+
 #include <algorithm>
 #include <cctype>
 #include <system_error>
@@ -218,6 +220,56 @@ bool AssetWatchEventQueue::TakeOverflowedLocked()
 size_t AssetWatchEventQueue::SizeLocked() const
 {
     return m_Events.size();
+}
+
+bool PublishAssetWatchEventLocked(
+    AssetWatchSuppressionRegistry& suppressionRegistry,
+    AssetWatchEventQueue& pendingEvents,
+    const std::filesystem::path& path,
+    AssetFileAction action)
+{
+    if (suppressionRegistry.IsSuppressedLocked(path))
+        return false;
+    return pendingEvents.EnqueueLocked(path, action);
+}
+
+std::vector<std::filesystem::path> AssetWatchSuppressionPaths(
+    AssetWatchOperationKind operation,
+    const std::filesystem::path& sourcePath,
+    const std::filesystem::path& destinationPath)
+{
+    if (sourcePath.empty())
+        return {};
+
+    std::vector<std::filesystem::path> paths{
+        sourcePath, AssetSidecarPath(sourcePath)};
+    switch (operation)
+    {
+    case AssetWatchOperationKind::Rename:
+    case AssetWatchOperationKind::Move:
+        if (!destinationPath.empty())
+        {
+            paths.push_back(destinationPath);
+            paths.push_back(AssetSidecarPath(destinationPath));
+        }
+        break;
+    case AssetWatchOperationKind::Reimport:
+    case AssetWatchOperationKind::Delete:
+        break;
+    }
+    return paths;
+}
+
+bool RunSuppressedAssetOperation(
+    AssetWatchSuppressionRegistry& suppressionRegistry,
+    AssetWatchOperationKind operationKind,
+    const std::filesystem::path& sourcePath,
+    const std::filesystem::path& destinationPath,
+    const AssetWatchSuppressedOperation& callback)
+{
+    suppressionRegistry.RegisterMany(AssetWatchSuppressionPaths(
+        operationKind, sourcePath, destinationPath));
+    return callback ? callback() : false;
 }
 
 AssetWatchRefreshAction DecideWatchRefreshAction(

--- a/RT2App/src/AssetWatchPolicy.cpp
+++ b/RT2App/src/AssetWatchPolicy.cpp
@@ -121,6 +121,13 @@ void AssetWatchSuppressionRegistry::RegisterLocked(
         m_Paths.push_back(normalized);
 }
 
+void AssetWatchSuppressionRegistry::RegisterManyLocked(
+    const std::vector<std::filesystem::path>& paths)
+{
+    for (const auto& path : paths)
+        RegisterLocked(path);
+}
+
 bool AssetWatchSuppressionRegistry::IsSuppressedLocked(
     const std::filesystem::path& path) const
 {

--- a/RT2App/src/AssetWatchPolicy.h
+++ b/RT2App/src/AssetWatchPolicy.h
@@ -55,6 +55,7 @@ public:
     // These methods require the caller to hold the mutex passed to the
     // constructor. They are the listener's atomic check/update seam.
     void RegisterLocked(const std::filesystem::path& path);
+    void RegisterManyLocked(const std::vector<std::filesystem::path>& paths);
     bool IsSuppressedLocked(const std::filesystem::path& path) const;
     void ClearLocked();
     size_t SizeLocked() const;
@@ -66,6 +67,20 @@ private:
 };
 
 constexpr size_t kAssetWatchQueueLimit = 100;
+constexpr int kAssetWatchDebounceMilliseconds = 100;
+
+enum class AssetWatchDriveKind
+{
+    Local,
+    Network,
+};
+
+// efsw's Windows default is 63 KiB. A larger buffer is safe for local
+// drives, but Windows rejects it for network shares.
+constexpr size_t AssetWatchBufferSize(AssetWatchDriveKind drive)
+{
+    return drive == AssetWatchDriveKind::Local ? 256u * 1024u : 63u * 1024u;
+}
 
 struct AssetWatchEvent
 {

--- a/RT2App/src/AssetWatchPolicy.h
+++ b/RT2App/src/AssetWatchPolicy.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#ifndef RT2_CORE_ASSET_WATCH_POLICY_H
+#define RT2_CORE_ASSET_WATCH_POLICY_H
+
+#include <cstddef>
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace rt2::core {
+
+enum class AssetFileAction
+{
+    Add,
+    Modified,
+    Delete,
+    Moved,
+};
+
+enum class AssetFileEventKind
+{
+    ScriptReload,
+    DatabaseRefresh,
+    Ignore,
+};
+
+AssetFileEventKind ClassifyAssetFileEvent(
+    const std::filesystem::path& path,
+    AssetFileAction action);
+
+bool AssetFileNeedsDatabaseRefresh(
+    const std::filesystem::path& path,
+    AssetFileAction action);
+
+// Watch paths are physical absolute paths. On Windows normalization also
+// folds case, matching the filesystem's event identity rules.
+std::string NormalizeWatchPath(const std::filesystem::path& path);
+
+class AssetWatchSuppressionRegistry
+{
+public:
+    // A host listener may provide its event mutex so suppression checks and
+    // event publication occur in one critical section. Tests use the private
+    // mutex supplied by the default constructor.
+    explicit AssetWatchSuppressionRegistry(std::mutex* sharedMutex = nullptr);
+
+    void Register(const std::filesystem::path& path);
+    void RegisterMany(const std::vector<std::filesystem::path>& paths);
+    bool IsSuppressed(const std::filesystem::path& path) const;
+    void Clear();
+    size_t Size() const;
+
+    // These methods require the caller to hold the mutex passed to the
+    // constructor. They are the listener's atomic check/update seam.
+    void RegisterLocked(const std::filesystem::path& path);
+    bool IsSuppressedLocked(const std::filesystem::path& path) const;
+    void ClearLocked();
+    size_t SizeLocked() const;
+
+private:
+    mutable std::mutex m_OwnMutex;
+    std::mutex* m_Mutex;
+    std::vector<std::string> m_Paths;
+};
+
+constexpr size_t kAssetWatchQueueLimit = 100;
+
+struct AssetWatchEvent
+{
+    std::string path;
+    AssetFileAction action = AssetFileAction::Modified;
+    AssetFileEventKind kind = AssetFileEventKind::Ignore;
+    bool refreshDatabase = false;
+};
+
+class AssetWatchEventQueue
+{
+public:
+    explicit AssetWatchEventQueue(std::mutex* sharedMutex = nullptr);
+
+    // Returns true when the event was accepted. A new event beyond the limit
+    // drops the oldest entry, retaining the most recent 100 paths and setting
+    // the overflow marker.
+    bool Enqueue(const std::filesystem::path& path, AssetFileAction action);
+    std::vector<AssetWatchEvent> Drain();
+    bool TakeOverflowed();
+    size_t Size() const;
+
+    bool EnqueueLocked(const std::filesystem::path& path,
+                       AssetFileAction action);
+    std::vector<AssetWatchEvent> DrainLocked();
+    bool TakeOverflowedLocked();
+    size_t SizeLocked() const;
+
+private:
+    mutable std::mutex m_OwnMutex;
+    std::mutex* m_Mutex;
+    std::vector<AssetWatchEvent> m_Events;
+    bool m_Overflowed = false;
+};
+
+enum class AssetWatchRefreshAction
+{
+    NoOp,
+    RefreshNow,
+    Queue,
+    Truncate,
+};
+
+AssetWatchRefreshAction DecideWatchRefreshAction(
+    bool hasMissedEvents,
+    size_t queueSize,
+    bool backgroundBusy);
+
+} // namespace rt2::core
+
+#endif // RT2_CORE_ASSET_WATCH_POLICY_H

--- a/RT2App/src/AssetWatchPolicy.h
+++ b/RT2App/src/AssetWatchPolicy.h
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <filesystem>
+#include <functional>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -115,6 +116,40 @@ private:
     std::vector<AssetWatchEvent> m_Events;
     bool m_Overflowed = false;
 };
+
+// The watcher thread must make the suppression check and queue publication
+// one operation under the host's shared mutex. No filesystem or scan work is
+// performed by this seam.
+bool PublishAssetWatchEventLocked(
+    AssetWatchSuppressionRegistry& suppressionRegistry,
+    AssetWatchEventQueue& pendingEvents,
+    const std::filesystem::path& path,
+    AssetFileAction action);
+
+enum class AssetWatchOperationKind
+{
+    Reimport,
+    Rename,
+    Move,
+    Delete,
+};
+
+std::vector<std::filesystem::path> AssetWatchSuppressionPaths(
+    AssetWatchOperationKind operation,
+    const std::filesystem::path& sourcePath,
+    const std::filesystem::path& destinationPath = {});
+
+using AssetWatchSuppressedOperation = std::function<bool()>;
+
+// Register the paths before invoking the operation, then leave the entries
+// installed for the host's W7-A2 delayed clear. The callback is deliberately
+// injected so CPU-only tests can observe the registry during the operation.
+bool RunSuppressedAssetOperation(
+    AssetWatchSuppressionRegistry& suppressionRegistry,
+    AssetWatchOperationKind operationKind,
+    const std::filesystem::path& sourcePath,
+    const std::filesystem::path& destinationPath,
+    const AssetWatchSuppressedOperation& callback);
 
 enum class AssetWatchRefreshAction
 {

--- a/RT2App/src/ContentBrowserOperations.cpp
+++ b/RT2App/src/ContentBrowserOperations.cpp
@@ -417,8 +417,12 @@ std::vector<ContentBrowserDependant> FindContentBrowserDependants(
         if (!slot.reference)
             continue;
         const bool matchesId = !record.assetId.IsNull() &&
+                               !slot.reference->assetId.IsNull() &&
                                slot.reference->assetId == record.assetId;
-        const bool matchesPath = record.assetId.IsNull() &&
+        // This is an advisory safety query, not the resolver: when IDs are
+        // absent or disagree, the same source path is still worth reporting
+        // so the delete confirmation cannot under-report a dependant.
+        const bool matchesPath = !matchesId &&
             ReferenceKey(slot.reference->path, assetRoot) == recordPath;
         if (!matchesId && !matchesPath)
             continue;

--- a/RT2App/src/ContentBrowserOperations.h
+++ b/RT2App/src/ContentBrowserOperations.h
@@ -80,8 +80,9 @@ std::vector<AssetRecord> SearchContentBrowserAssets(
     const AssetDatabase& database, std::string_view query);
 
 // Dependants are derived from the live scene, not AssetDatabase's optional
-// cached dependency fields. ID is authoritative when present; sourcePath is
-// the fallback for nil-ID legacy references.
+// cached dependency fields. IDs match exactly when both sides have one;
+// sourcePath is the fallback when the scene has a nil or conflicting ID so
+// this safety warning cannot under-report a dependant.
 std::vector<ContentBrowserDependant> FindContentBrowserDependants(
     const SceneDocument& document,
     const AssetRecord& record,

--- a/RT2App/src/WalnutApp.cpp
+++ b/RT2App/src/WalnutApp.cpp
@@ -55,6 +55,7 @@
 #include "efsw/efsw.hpp"
 
 #include <cstdio>
+#include <cfloat>
 #include <cmath>
 #include <thread>
 #include <chrono>
@@ -1432,17 +1433,25 @@ public:
 			ImGui::EndPopup();
 		}
 
+		ImGui::SetNextWindowSizeConstraints(ImVec2(420, 0),
+			ImVec2(FLT_MAX, 400));
 		if (ImGui::BeginPopupModal("Delete Asset", nullptr,
 			ImGuiWindowFlags_AlwaysAutoResize))
 		{
-			ImGui::TextWrapped("Delete the source and its identity sidecar? This does not rewrite the scene.");
+			ImGui::PushTextWrapPos(400.0f);
+			ImGui::TextWrapped("Delete the source and its identity sidecar? "
+				"This does not rewrite the scene.");
+			ImGui::PopTextWrapPos();
 			if (!m_ContentBrowserDeleteDependants.empty())
 			{
-				ImGui::Text("Dependants in the current scene:");
+				ImGui::Text("Dependants in the current scene (%zu):",
+					m_ContentBrowserDeleteDependants.size());
+				ImGui::BeginChild("DeleteDependants", ImVec2(0, 150), true);
 				for (const auto& dependant : m_ContentBrowserDeleteDependants)
 					ImGui::BulletText("%s (%s)",
 						dependant.entityName.empty() ? "Environment" : dependant.entityName.c_str(),
 						dependant.sourceKey.c_str());
+				ImGui::EndChild();
 			}
 			ImGui::Checkbox("I understand references may become unresolved",
 				&m_ContentBrowserDeleteConfirmed);

--- a/RT2App/src/WalnutApp.cpp
+++ b/RT2App/src/WalnutApp.cpp
@@ -1248,6 +1248,9 @@ public:
 			*m_ProjectContext->database, m_ContentBrowserSearch);
 		if (records.empty())
 			ImGui::TextDisabled("No matching assets");
+		bool openRename = false;
+		bool openMove = false;
+		bool openDelete = false;
 		for (const auto& record : records)
 		{
 			ImGui::PushID(record.sourcePath.c_str());
@@ -1274,12 +1277,12 @@ public:
 						.filename().u8string();
 					std::snprintf(m_ContentBrowserRenameBuffer,
 						sizeof(m_ContentBrowserRenameBuffer), "%s", filename.c_str());
-					ImGui::OpenPopup("Rename Asset");
+					openRename = true;
 				}
 				if (ImGui::MenuItem("Move..."))
 				{
 					m_ContentBrowserMoveBuffer[0] = '\0';
-					ImGui::OpenPopup("Move Asset");
+					openMove = true;
 				}
 				if (ImGui::MenuItem("Reimport"))
 				{
@@ -1334,12 +1337,18 @@ public:
 						rt2::core::FindContentBrowserDependants(
 							m_SceneMgr.AuthoringDoc(), record,
 							m_ProjectContext->project.assetRoot);
-					ImGui::OpenPopup("Delete Asset");
+					openDelete = true;
 				}
 				ImGui::EndPopup();
 			}
 			ImGui::PopID();
 		}
+		if (openRename)
+			ImGui::OpenPopup("Rename Asset");
+		if (openMove)
+			ImGui::OpenPopup("Move Asset");
+		if (openDelete)
+			ImGui::OpenPopup("Delete Asset");
 
 		if (ImGui::BeginPopupModal("Rename Asset", nullptr,
 			ImGuiWindowFlags_AlwaysAutoResize))

--- a/RT2App/src/WalnutApp.cpp
+++ b/RT2App/src/WalnutApp.cpp
@@ -64,6 +64,7 @@
 #include <cctype>
 #include <cstdlib>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -77,6 +78,26 @@
 #endif
 
 using namespace Walnut;
+
+namespace {
+
+std::filesystem::path ExecutableDirectory()
+{
+#ifdef _WIN32
+	std::wstring buffer(32768, L'\0');
+	const DWORD length = GetModuleFileNameW(nullptr, buffer.data(),
+		static_cast<DWORD>(buffer.size()));
+	if (length > 0 && length < buffer.size())
+	{
+		buffer.resize(length);
+		return std::filesystem::path(buffer).parent_path();
+	}
+#endif
+	printf("[ImGui] Could not determine the executable directory; portable imgui.ini fallback is unavailable\n");
+	return {};
+}
+
+} // namespace
 
 static CLIArgs g_CLI;
 
@@ -360,6 +381,48 @@ public:
 
 	virtual void OnUIRender() override
 	{
+		// ImGui's default is a cwd-relative path. Keep writes in the user's
+		// application-data directory, while accepting an executable-local file
+		// as a read-only seed for portable installs.
+		if (!m_ImGuiIniConfigured)
+		{
+			const auto userIniPath = AppDataRoot() / "imgui.ini";
+			m_ImGuiIniPath = userIniPath.string();
+			std::error_code directoryError;
+			std::filesystem::create_directories(userIniPath.parent_path(),
+				directoryError);
+			if (directoryError)
+				printf("[ImGui] Failed to create config directory \"%s\": %s\n",
+					userIniPath.parent_path().u8string().c_str(),
+					directoryError.message().c_str());
+
+			std::filesystem::path loadIniPath = userIniPath;
+			std::error_code userIniError;
+			const bool hasUserIni = std::filesystem::is_regular_file(
+				userIniPath, userIniError) && !userIniError;
+			if (!hasUserIni)
+			{
+				const auto executableDirectory = ExecutableDirectory();
+				if (!executableDirectory.empty())
+				{
+					const auto portableIniPath = executableDirectory / "imgui.ini";
+					std::error_code portableIniError;
+					if (std::filesystem::is_regular_file(
+							portableIniPath, portableIniError) && !portableIniError)
+					{
+						loadIniPath = portableIniPath;
+						printf("[ImGui] Seeding user layout from portable config \"%s\"\n",
+							portableIniPath.u8string().c_str());
+					}
+				}
+			}
+
+			ImGui::GetIO().IniFilename = m_ImGuiIniPath.c_str();
+			const auto loadIniString = loadIniPath.string();
+			ImGui::LoadIniSettingsFromDisk(loadIniString.c_str());
+			m_ImGuiIniConfigured = true;
+		}
+
 		// Phase 5: ResolveUI applies ImGui suppression and viewport
 		// sub-context push/pop. The viewport hover / gizmo-consumes-mouse
 		// state from the PREVIOUS frame is used here (we don't know
@@ -1222,39 +1285,41 @@ public:
 				{
 					rt2::core::ContentBrowserOperationReport report;
 					rt2::core::Error error;
-					RegisterAssetWatchPaths(
-						m_ProjectContext->project.assetRoot, record);
-					const bool ok = rt2::core::ReimportContentBrowserAsset(
+					const bool ok = RunAssetWatchSuppressedOperation(
 						m_ProjectContext->project.assetRoot, record,
-						[this](const rt2::core::AssetRecord& sourceRecord,
-						       const std::filesystem::path& source,
-						       std::vector<rt2::core::AssetDiagnostic>& diagnostics,
-						       rt2::core::Error& importError) {
-							const std::string path = source.u8string();
-							SceneManager::EntityId imported;
-							std::string extension = source.extension().u8string();
-							std::transform(extension.begin(), extension.end(), extension.begin(),
-								[](unsigned char c) {
-									return static_cast<char>(std::tolower(c));
-								});
-							if (extension == ".obj")
-								imported = m_SceneMgr.ImportObj(
-									path, sourceRecord.importSettings, &diagnostics);
-							else
-								imported = m_SceneMgr.ImportGltf(path, &diagnostics);
-							if (!imported.IsValid())
-							{
-								importError.code = rt2::core::Error::InvalidArgument;
-								importError.path = path;
-								importError.detail = "existing scene import path rejected the asset";
-								return false;
-							}
-							m_SceneMgr.MarkDirty();
-							m_PendingFullSync = true;
-							m_GpuSyncPending = true;
-							m_EditorUI.OnImportComplete(imported);
-							return true;
-						}, report, error);
+						rt2::core::AssetWatchOperationKind::Reimport, {}, [&]() {
+							return rt2::core::ReimportContentBrowserAsset(
+								m_ProjectContext->project.assetRoot, record,
+								[this](const rt2::core::AssetRecord& sourceRecord,
+								       const std::filesystem::path& source,
+								       std::vector<rt2::core::AssetDiagnostic>& diagnostics,
+								       rt2::core::Error& importError) {
+									const std::string path = source.u8string();
+									SceneManager::EntityId imported;
+									std::string extension = source.extension().u8string();
+									std::transform(extension.begin(), extension.end(), extension.begin(),
+										[](unsigned char c) {
+											return static_cast<char>(std::tolower(c));
+										});
+									if (extension == ".obj")
+										imported = m_SceneMgr.ImportObj(
+											path, sourceRecord.importSettings, &diagnostics);
+									else
+										imported = m_SceneMgr.ImportGltf(path, &diagnostics);
+									if (!imported.IsValid())
+									{
+										importError.code = rt2::core::Error::InvalidArgument;
+										importError.path = path;
+										importError.detail = "existing scene import path rejected the asset";
+										return false;
+									}
+									m_SceneMgr.MarkDirty();
+									m_PendingFullSync = true;
+									m_GpuSyncPending = true;
+									m_EditorUI.OnImportComplete(imported);
+									return true;
+								}, report, error);
+						});
 					const bool refreshed = ok && RefreshProjectAssets();
 					ScheduleAssetWatchSuppressionClear();
 					if (refreshed)
@@ -1290,14 +1355,15 @@ public:
 						m_ContentBrowserPendingRecord->sourcePath);
 				const auto destination = source.parent_path() /
 					std::filesystem::u8path(m_ContentBrowserRenameBuffer);
-				RegisterAssetWatchPaths(
+				const bool ok = RunAssetWatchSuppressedOperation(
 					m_ProjectContext->project.assetRoot,
 					*m_ContentBrowserPendingRecord,
-					{destination, rt2::core::AssetSidecarPath(destination)});
-				const bool ok = rt2::core::RenameContentBrowserAsset(
-					m_ProjectContext->project.assetRoot,
-					*m_ContentBrowserPendingRecord,
-					m_ContentBrowserRenameBuffer, report, error);
+					rt2::core::AssetWatchOperationKind::Rename, destination, [&]() {
+						return rt2::core::RenameContentBrowserAsset(
+							m_ProjectContext->project.assetRoot,
+							*m_ContentBrowserPendingRecord,
+							m_ContentBrowserRenameBuffer, report, error);
+					});
 				const bool refreshed = ok && RefreshProjectAssets();
 				ScheduleAssetWatchSuppressionClear();
 				if (refreshed)
@@ -1334,15 +1400,16 @@ public:
 				const auto destinationDirectory =
 					std::filesystem::u8path(m_ContentBrowserMoveBuffer);
 				const auto destination = destinationDirectory / source.filename();
-				RegisterAssetWatchPaths(
+				const bool ok = RunAssetWatchSuppressedOperation(
 					m_ProjectContext->project.assetRoot,
 					*m_ContentBrowserPendingRecord,
-					{destination, rt2::core::AssetSidecarPath(destination)});
-				const bool ok = rt2::core::MoveContentBrowserAsset(
-					m_ProjectContext->project.assetRoot,
-					*m_ContentBrowserPendingRecord,
-					std::filesystem::u8path(m_ContentBrowserMoveBuffer),
-					report, error);
+					rt2::core::AssetWatchOperationKind::Move, destination, [&]() {
+						return rt2::core::MoveContentBrowserAsset(
+							m_ProjectContext->project.assetRoot,
+							*m_ContentBrowserPendingRecord,
+							std::filesystem::u8path(m_ContentBrowserMoveBuffer),
+							report, error);
+					});
 				const bool refreshed = ok && RefreshProjectAssets();
 				ScheduleAssetWatchSuppressionClear();
 				if (refreshed)
@@ -1377,12 +1444,14 @@ public:
 			{
 				rt2::core::ContentBrowserOperationReport report;
 				rt2::core::Error error;
-				RegisterAssetWatchPaths(
+				const bool ok = RunAssetWatchSuppressedOperation(
 					m_ProjectContext->project.assetRoot,
-					*m_ContentBrowserPendingRecord);
-				const bool ok = rt2::core::DeleteContentBrowserAsset(
-					m_ProjectContext->project.assetRoot,
-					*m_ContentBrowserPendingRecord, report, error);
+					*m_ContentBrowserPendingRecord,
+					rt2::core::AssetWatchOperationKind::Delete, {}, [&]() {
+						return rt2::core::DeleteContentBrowserAsset(
+							m_ProjectContext->project.assetRoot,
+							*m_ContentBrowserPendingRecord, report, error);
+					});
 				const bool refreshed = ok && RefreshProjectAssets();
 				ScheduleAssetWatchSuppressionClear();
 				if (refreshed)
@@ -2972,6 +3041,8 @@ private:
 	bool m_PendingFullSync = false;
 	Camera m_Cam;
 	bool m_CLIProcessed = false;
+	bool m_ImGuiIniConfigured = false;
+	std::string m_ImGuiIniPath;
 
 	// Runtime lifecycle
 	SceneRenderBridge* m_RenderBridge = nullptr;
@@ -3046,9 +3117,8 @@ private:
 			// Registry lookup and event publication are atomic. No filesystem
 			// or scan work is allowed while this mutex is held.
 			std::lock_guard<std::mutex> lock(mutex);
-			if (suppressionRegistry.IsSuppressedLocked(full))
-				return;
-			pendingEvents.EnqueueLocked(full, assetAction);
+			rt2::core::PublishAssetWatchEventLocked(
+				suppressionRegistry, pendingEvents, full, assetAction);
 		}
 
 		void handleMissedFileActions(efsw::WatchID watchid,
@@ -3188,21 +3258,21 @@ private:
 		}
 	}
 
-	void RegisterAssetWatchPaths(
+	bool RunAssetWatchSuppressedOperation(
 		const std::filesystem::path& assetRoot,
 		const rt2::core::AssetRecord& record,
-		const std::vector<std::filesystem::path>& additional = {})
+		rt2::core::AssetWatchOperationKind operationKind,
+		const std::filesystem::path& destination,
+		const rt2::core::AssetWatchSuppressedOperation& callback)
 	{
-		if (!m_FileWatchListener || assetRoot.empty() ||
-			record.sourcePath.empty())
-			return;
+		if (!m_FileWatchListener)
+			return callback ? callback() : false;
 		const auto source = (assetRoot /
 			std::filesystem::u8path(record.sourcePath)).lexically_normal();
-		std::vector<std::filesystem::path> paths{
-			source, rt2::core::AssetSidecarPath(source)};
-		paths.insert(paths.end(), additional.begin(), additional.end());
-		std::lock_guard<std::mutex> lock(m_FileWatchListener->mutex);
-		m_FileWatchListener->suppressionRegistry.RegisterManyLocked(paths);
+		return rt2::core::RunSuppressedAssetOperation(
+			m_FileWatchListener->suppressionRegistry,
+			operationKind, source, destination,
+			callback);
 	}
 
 	void ScheduleAssetWatchSuppressionClear()

--- a/RT2App/src/WalnutApp.cpp
+++ b/RT2App/src/WalnutApp.cpp
@@ -26,6 +26,8 @@
 #include "ScriptAssetPath.h"
 #include "ScriptFieldChangePolicy.h"
 #include "ScriptFileWatchPolicy.h"
+#include "AssetWatchPolicy.h"
+#include "AssetIdentity.h"
 #include "SceneRenderBridge.h"
 #include "ECSComponents.h"
 #include "EditorSettings.h"
@@ -65,8 +67,14 @@
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <set>
 #include <sstream>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
 
 using namespace Walnut;
 
@@ -172,7 +180,7 @@ public:
 		m_InspectorFieldRegistry = std::make_unique<rt2::core::ScriptFieldRegistry>();
 
 		// Phase 6C/W2: file watcher for hot reload.
-		m_FileWatchListener = std::make_unique<ScriptFileWatchListener>();
+		m_FileWatchListener = std::make_unique<AssetWatchListener>();
 		m_FileWatcher = std::make_unique<efsw::FileWatcher>();
 		m_FileWatcher->watch();
 
@@ -1055,55 +1063,10 @@ public:
 	DrawUnsavedChangesPrompt();
 	DrawLoadingModal();
 
-	// Phase 6C/W2: drain file-watcher changes with debounce. Atomic save
-	// (temp + rename) yields Modified + Added + Deleted for one Ctrl+S.
-	// Coalesce by path over a ~100ms quiet window, then reload.
-	if (m_FileWatchListener)
-	{
-		{
-			std::lock_guard<std::mutex> lock(m_FileWatchListener->mutex);
-			if (!m_FileWatchListener->pendingChanges.empty())
-			{
-				for (const auto& p : m_FileWatchListener->pendingChanges)
-				{
-					// Dedupe: don't add a path already in the debounce buffer.
-					if (std::find(m_DebouncedChanges.begin(),
-					              m_DebouncedChanges.end(), p) ==
-					    m_DebouncedChanges.end())
-						m_DebouncedChanges.push_back(p);
-				}
-				m_FileWatchListener->pendingChanges.clear();
-				m_LastFileChangeTime = std::chrono::steady_clock::now();
-			}
-		}
-
-		// If no new changes for 100ms and we have pending, drain.
-		if (!m_DebouncedChanges.empty())
-		{
-			const auto now = std::chrono::steady_clock::now();
-			const auto elapsed = std::chrono::duration_cast<
-				std::chrono::milliseconds>(now - m_LastFileChangeTime);
-			if (elapsed.count() >= 100)
-			{
-				auto changes = std::move(m_DebouncedChanges);
-				m_DebouncedChanges.clear();
-				const auto action = rt2::core::DecideScriptFileChange(
-					m_Runtime.GetState(),
-					m_ScriptSystem != nullptr,
-					m_InspectorFieldRegistry != nullptr);
-				for (const auto& path : changes)
-				{
-					if (action.reloadScript)
-						m_ScriptSystem->ReloadScript(path);
-				}
-				// Once per drain, not per path: the inspector cache is
-				// whole-registry, so clearing it per file would be
-				// redundant work.
-				if (action.invalidateFieldRegistry)
-					m_InspectorFieldRegistry->Clear();
-			}
-		}
-	}
+	// The efsw callback only publishes classified events under its mutex.
+	// Filesystem scans, script reloads, and status work happen outside that
+	// critical section on the main thread.
+	DrainAssetWatchChanges(false);
 
 	// Phase 5: EndFrame commits current → previous state, clears
 	// per-frame deltas, and applies cursor capture. Called at the end
@@ -1259,6 +1222,8 @@ public:
 				{
 					rt2::core::ContentBrowserOperationReport report;
 					rt2::core::Error error;
+					RegisterAssetWatchPaths(
+						m_ProjectContext->project.assetRoot, record);
 					const bool ok = rt2::core::ReimportContentBrowserAsset(
 						m_ProjectContext->project.assetRoot, record,
 						[this](const rt2::core::AssetRecord& sourceRecord,
@@ -1290,7 +1255,9 @@ public:
 							m_EditorUI.OnImportComplete(imported);
 							return true;
 						}, report, error);
-					if (ok && RefreshProjectAssets())
+					const bool refreshed = ok && RefreshProjectAssets();
+					ScheduleAssetWatchSuppressionClear();
+					if (refreshed)
 						m_LastStatusMsg = "Asset reimported";
 					else if (!ok)
 						m_LastStatusMsg = "Asset reimport failed: " + error.Format();
@@ -1318,11 +1285,22 @@ public:
 			{
 				rt2::core::ContentBrowserOperationReport report;
 				rt2::core::Error error;
+				const auto source = m_ProjectContext->project.assetRoot /
+					std::filesystem::u8path(
+						m_ContentBrowserPendingRecord->sourcePath);
+				const auto destination = source.parent_path() /
+					std::filesystem::u8path(m_ContentBrowserRenameBuffer);
+				RegisterAssetWatchPaths(
+					m_ProjectContext->project.assetRoot,
+					*m_ContentBrowserPendingRecord,
+					{destination, rt2::core::AssetSidecarPath(destination)});
 				const bool ok = rt2::core::RenameContentBrowserAsset(
 					m_ProjectContext->project.assetRoot,
 					*m_ContentBrowserPendingRecord,
 					m_ContentBrowserRenameBuffer, report, error);
-				if (ok && RefreshProjectAssets())
+				const bool refreshed = ok && RefreshProjectAssets();
+				ScheduleAssetWatchSuppressionClear();
+				if (refreshed)
 					m_LastStatusMsg = "Asset renamed";
 				else if (!ok)
 					m_LastStatusMsg = "Asset rename failed: " + error.Format();
@@ -1350,12 +1328,24 @@ public:
 			{
 				rt2::core::ContentBrowserOperationReport report;
 				rt2::core::Error error;
+				const auto source = m_ProjectContext->project.assetRoot /
+					std::filesystem::u8path(
+						m_ContentBrowserPendingRecord->sourcePath);
+				const auto destinationDirectory =
+					std::filesystem::u8path(m_ContentBrowserMoveBuffer);
+				const auto destination = destinationDirectory / source.filename();
+				RegisterAssetWatchPaths(
+					m_ProjectContext->project.assetRoot,
+					*m_ContentBrowserPendingRecord,
+					{destination, rt2::core::AssetSidecarPath(destination)});
 				const bool ok = rt2::core::MoveContentBrowserAsset(
 					m_ProjectContext->project.assetRoot,
 					*m_ContentBrowserPendingRecord,
 					std::filesystem::u8path(m_ContentBrowserMoveBuffer),
 					report, error);
-				if (ok && RefreshProjectAssets())
+				const bool refreshed = ok && RefreshProjectAssets();
+				ScheduleAssetWatchSuppressionClear();
+				if (refreshed)
 					m_LastStatusMsg = "Asset moved";
 				else if (!ok)
 					m_LastStatusMsg = "Asset move failed: " + error.Format();
@@ -1387,10 +1377,15 @@ public:
 			{
 				rt2::core::ContentBrowserOperationReport report;
 				rt2::core::Error error;
+				RegisterAssetWatchPaths(
+					m_ProjectContext->project.assetRoot,
+					*m_ContentBrowserPendingRecord);
 				const bool ok = rt2::core::DeleteContentBrowserAsset(
 					m_ProjectContext->project.assetRoot,
 					*m_ContentBrowserPendingRecord, report, error);
-				if (ok && RefreshProjectAssets())
+				const bool refreshed = ok && RefreshProjectAssets();
+				ScheduleAssetWatchSuppressionClear();
+				if (refreshed)
 					m_LastStatusMsg = "Asset deleted";
 				else if (!ok)
 					m_LastStatusMsg = "Asset delete failed: " + error.Format();
@@ -1466,6 +1461,9 @@ public:
 			if (ok)
 			{
 				m_ProjectContext = std::move(recoveryProject);
+				ConfigureAssetRootWatch(m_ProjectContext
+					? m_ProjectContext->project.assetRoot
+					: std::filesystem::path{});
 				m_SceneMgr.SetAssetResolutionContext(assetContext);
 				m_ScriptAssetContext = assetContext;
 				ApplyActiveInputConfiguration();
@@ -1663,6 +1661,9 @@ public:
 				m_GpuSyncStatus = "Preparing GPU upload...";
 				cb(success);
 			}
+			// The worker is idle now; process events queued during the
+			// operation without waiting for another debounce window.
+			DrainAssetWatchChanges(true);
 			printf("[LoadingModal] Phase 1 done: gpuSyncPending=%d\n", m_GpuSyncPending ? 1 : 0);
 			fflush(stdout);
 			// If the callback didn't set m_GpuSyncPending there is nothing
@@ -1789,6 +1790,7 @@ public:
 			m_OnBackgroundComplete = nullptr;
 			cb(success);
 		}
+		DrainAssetWatchChanges(true);
 
 		// Run the GPU sync phase synchronously (headless has no UI loop).
 		if (m_GpuSyncPending && m_RendererGPU.IsAvailable())
@@ -2993,38 +2995,70 @@ private:
 	// load/close alongside ResetForDocument.
 	std::unique_ptr<rt2::core::ScriptFieldRegistry> m_InspectorFieldRegistry;
 
-	// Phase 6C/W2: file watcher for hot reload. efsw watches directories
-	// containing referenced script assets. On .lua file change, the path
-	// is posted to m_PendingFileChanges (thread-safe). The drain in
-	// OnUIRender debounces (~100ms) and calls ScriptSystem::ReloadScript.
-	class ScriptFileWatchListener : public efsw::FileWatchListener
+	// Phase 7: the assetRoot watcher classifies script, database, and ignored
+	// paths before publishing them to the main-thread drain.
+	class AssetWatchListener : public efsw::FileWatchListener
 	{
 	public:
 		std::mutex mutex;
-		std::vector<std::string> pendingChanges;
+		rt2::core::AssetWatchSuppressionRegistry suppressionRegistry;
+		rt2::core::AssetWatchEventQueue pendingEvents;
+		bool missedEvents = false;
+		std::string missedDirectory;
+
+		AssetWatchListener()
+			: suppressionRegistry(&mutex), pendingEvents(&mutex) {}
 
 		void handleFileAction(efsw::WatchID watchid, const std::string& dir,
 		                      const std::string& filename, efsw::Action action,
 		                      const std::string& oldFilename) override
 		{
 			(void)watchid; (void)oldFilename;
+			rt2::core::AssetFileAction assetAction;
+			switch (action)
+			{
+			case efsw::Actions::Add:
+				assetAction = rt2::core::AssetFileAction::Add;
+				break;
+			case efsw::Actions::Modified:
+				assetAction = rt2::core::AssetFileAction::Modified;
+				break;
+			case efsw::Actions::Delete:
+				assetAction = rt2::core::AssetFileAction::Delete;
+				break;
+			case efsw::Actions::Moved:
+				assetAction = rt2::core::AssetFileAction::Moved;
+				break;
+			default:
+				return;
+			}
 			// Only react to .lua file modifications and adds (atomic save =
 			// delete + add, so catch both). Delete alone means the file is
 			// gone — no reload needed.
-			if (action == efsw::Actions::Delete) return;
 
 			// Only .lua files (case-insensitive on Windows).
-			if (filename.size() < 5) return;
-			auto ext = filename.substr(filename.size() - 4);
-			std::transform(ext.begin(), ext.end(), ext.begin(),
-				[](unsigned char c) { return std::tolower(c); });
-			if (ext != ".lua") return;
+			const std::filesystem::path full =
+				std::filesystem::path(dir) / std::filesystem::u8path(filename);
+			if (rt2::core::ClassifyAssetFileEvent(full, assetAction) ==
+				rt2::core::AssetFileEventKind::Ignore)
+				return;
 
-			// Build the full path. efsw gives dir + filename separately;
-			// normalize to a single path.
-			std::filesystem::path full = std::filesystem::path(dir) / filename;
+			// Registry lookup and event publication are atomic. No filesystem
+			// or scan work is allowed while this mutex is held.
 			std::lock_guard<std::mutex> lock(mutex);
-			pendingChanges.push_back(full.string());
+			if (suppressionRegistry.IsSuppressedLocked(full))
+				return;
+			pendingEvents.EnqueueLocked(full, assetAction);
+		}
+
+		void handleMissedFileActions(efsw::WatchID watchid,
+		                             const std::string& dir) override
+		{
+			(void)watchid;
+			std::lock_guard<std::mutex> lock(mutex);
+			missedEvents = true;
+			missedDirectory = rt2::core::NormalizeWatchPath(
+				std::filesystem::u8path(dir));
 		}
 	};
 
@@ -3033,11 +3067,15 @@ private:
 	// ~FileWatcher) never calls handleFileAction on a destroyed
 	// listener. Members destroy in reverse declaration order, so
 	// the watcher is declared second and dies first.
-	std::unique_ptr<ScriptFileWatchListener>    m_FileWatchListener;
+	std::unique_ptr<AssetWatchListener>        m_FileWatchListener;
 	std::unique_ptr<efsw::FileWatcher>          m_FileWatcher;
-	std::vector<efsw::WatchID>                  m_ActiveWatchIds;
+	std::optional<efsw::WatchID>                m_ActiveWatchId;
 	std::vector<std::string>                    m_DebouncedChanges;
+	std::vector<std::string>                    m_DebouncedRefreshPaths;
 	std::chrono::steady_clock::time_point       m_LastFileChangeTime;
+	bool                                        m_AssetWatchMissedEvents = false;
+	std::string                                 m_AssetWatchMissedDirectory;
+	bool                                        m_AssetWatchClearSuppressionNextDrain = false;
 
 	// Phase 5 input service — owns the context stack and frame phasing.
 	rt2::core::InputService m_Input;
@@ -3148,6 +3186,221 @@ private:
 				diagnostic.refPath.c_str(), diagnostic.sourceKey.c_str(),
 				diagnostic.detail.c_str());
 		}
+	}
+
+	void RegisterAssetWatchPaths(
+		const std::filesystem::path& assetRoot,
+		const rt2::core::AssetRecord& record,
+		const std::vector<std::filesystem::path>& additional = {})
+	{
+		if (!m_FileWatchListener || assetRoot.empty() ||
+			record.sourcePath.empty())
+			return;
+		const auto source = (assetRoot /
+			std::filesystem::u8path(record.sourcePath)).lexically_normal();
+		std::vector<std::filesystem::path> paths{
+			source, rt2::core::AssetSidecarPath(source)};
+		paths.insert(paths.end(), additional.begin(), additional.end());
+		std::lock_guard<std::mutex> lock(m_FileWatchListener->mutex);
+		m_FileWatchListener->suppressionRegistry.RegisterManyLocked(paths);
+	}
+
+	void ScheduleAssetWatchSuppressionClear()
+	{
+		// W7-A2: leave the entries installed through the drain that follows the
+		// W6 refresh, because efsw may deliver the operation's events late.
+		m_AssetWatchClearSuppressionNextDrain = true;
+	}
+
+	void DrainAssetWatchChanges(bool force)
+	{
+		if (!m_FileWatchListener)
+			return;
+
+		std::vector<rt2::core::AssetWatchEvent> events;
+		bool overflowed = false;
+		{
+			// The listener owns both the registry and queue under this mutex.
+			// Move only already-published data out; all filesystem and scan work
+			// below happens after the lock is released.
+			std::lock_guard<std::mutex> lock(m_FileWatchListener->mutex);
+			events = m_FileWatchListener->pendingEvents.DrainLocked();
+			overflowed = m_FileWatchListener->pendingEvents.TakeOverflowedLocked();
+			if (m_FileWatchListener->missedEvents)
+			{
+				m_AssetWatchMissedEvents = true;
+				m_AssetWatchMissedDirectory =
+					m_FileWatchListener->missedDirectory;
+				m_FileWatchListener->missedEvents = false;
+				m_FileWatchListener->missedDirectory.clear();
+			}
+			// Clear only after taking this cycle's events so late delivery from
+			// the W6 operation remains suppressed for one complete drain.
+			if (m_AssetWatchClearSuppressionNextDrain)
+			{
+				m_FileWatchListener->suppressionRegistry.ClearLocked();
+				m_AssetWatchClearSuppressionNextDrain = false;
+			}
+		}
+
+		if (overflowed)
+		{
+			m_AssetWatchMissedEvents = true;
+			m_LastStatusMsg =
+				"Asset change queue overflowed; use Refresh for a full scan";
+			printf("[FileWatcher] Asset change queue overflowed; forcing a full scan\n");
+		}
+
+		for (const auto& event : events)
+		{
+			if (event.kind == rt2::core::AssetFileEventKind::ScriptReload &&
+				std::find(m_DebouncedChanges.begin(), m_DebouncedChanges.end(),
+					event.path) == m_DebouncedChanges.end())
+				m_DebouncedChanges.push_back(event.path);
+			if (event.refreshDatabase &&
+				std::find(m_DebouncedRefreshPaths.begin(),
+				          m_DebouncedRefreshPaths.end(), event.path) ==
+					m_DebouncedRefreshPaths.end())
+				m_DebouncedRefreshPaths.push_back(event.path);
+		}
+		if (!events.empty())
+			m_LastFileChangeTime = std::chrono::steady_clock::now();
+
+		// Keep the main-thread debounce buffers bounded as well as the listener
+		// queue. Losing an event promotes the cycle to a full scan.
+		while (m_DebouncedChanges.size() + m_DebouncedRefreshPaths.size() >
+			rt2::core::kAssetWatchQueueLimit)
+		{
+			if (!m_DebouncedRefreshPaths.empty())
+				m_DebouncedRefreshPaths.erase(m_DebouncedRefreshPaths.begin());
+			else
+				m_DebouncedChanges.erase(m_DebouncedChanges.begin());
+			m_AssetWatchMissedEvents = true;
+		}
+
+		const size_t pendingCount = m_DebouncedChanges.size() +
+			m_DebouncedRefreshPaths.size();
+		const auto decision = rt2::core::DecideWatchRefreshAction(
+			m_AssetWatchMissedEvents, pendingCount, IsBackgroundBusy());
+		if (decision == rt2::core::AssetWatchRefreshAction::Queue ||
+			decision == rt2::core::AssetWatchRefreshAction::Truncate)
+		{
+			if (pendingCount > 0 || m_AssetWatchMissedEvents)
+			{
+				m_LastStatusMsg = decision ==
+					rt2::core::AssetWatchRefreshAction::Truncate
+					? "Asset changes queued; oldest events were truncated"
+					: "Asset changes queued; waiting for background work to finish";
+			}
+			return;
+		}
+		if (decision == rt2::core::AssetWatchRefreshAction::NoOp)
+			return;
+
+		const auto now = std::chrono::steady_clock::now();
+		const auto elapsed = std::chrono::duration_cast<
+			std::chrono::milliseconds>(now - m_LastFileChangeTime);
+		if (!force && !m_AssetWatchMissedEvents &&
+			elapsed.count() < rt2::core::kAssetWatchDebounceMilliseconds)
+			return;
+
+		auto scriptChanges = std::move(m_DebouncedChanges);
+		m_DebouncedChanges.clear();
+		auto refreshPaths = std::move(m_DebouncedRefreshPaths);
+		m_DebouncedRefreshPaths.clear();
+		const auto scriptAction = rt2::core::DecideScriptFileChange(
+			m_Runtime.GetState(), m_ScriptSystem != nullptr,
+			m_InspectorFieldRegistry != nullptr);
+		for (const auto& path : scriptChanges)
+		{
+			if (scriptAction.reloadScript && m_ScriptSystem)
+				m_ScriptSystem->ReloadScript(path);
+		}
+		if (scriptAction.invalidateFieldRegistry && m_InspectorFieldRegistry)
+			m_InspectorFieldRegistry->Clear();
+
+		if (m_AssetWatchMissedEvents || !refreshPaths.empty())
+		{
+			if (m_AssetWatchMissedEvents)
+			{
+				m_LastStatusMsg =
+					"File system events may have been missed; refreshing the asset database";
+				printf("[FileWatcher] %s (%s)\n", m_LastStatusMsg.c_str(),
+					m_AssetWatchMissedDirectory.c_str());
+			}
+			RefreshProjectAssets();
+		}
+		if (!scriptChanges.empty() && refreshPaths.empty() &&
+			!m_AssetWatchMissedEvents)
+			m_LastStatusMsg = "Scripts reloaded";
+		m_AssetWatchMissedEvents = false;
+		m_AssetWatchMissedDirectory.clear();
+	}
+
+	bool IsNetworkWatchRoot(const std::filesystem::path& assetRoot) const
+	{
+#ifdef _WIN32
+		std::wstring root = assetRoot.root_path().wstring();
+		if (!root.empty() && root.back() != L'\\')
+			root.push_back(L'\\');
+		return !root.empty() && GetDriveTypeW(root.c_str()) == DRIVE_REMOTE;
+#else
+		(void)assetRoot;
+		return false;
+#endif
+	}
+
+	void ConfigureAssetRootWatch(const std::filesystem::path& assetRoot)
+	{
+		if (!m_FileWatchListener || !m_FileWatcher)
+			return;
+		if (m_ActiveWatchId)
+		{
+			m_FileWatcher->removeWatch(*m_ActiveWatchId);
+			m_ActiveWatchId.reset();
+		}
+		{
+			std::lock_guard<std::mutex> lock(m_FileWatchListener->mutex);
+			m_FileWatchListener->pendingEvents.DrainLocked();
+			m_FileWatchListener->pendingEvents.TakeOverflowedLocked();
+			m_FileWatchListener->suppressionRegistry.ClearLocked();
+			m_FileWatchListener->missedEvents = false;
+			m_FileWatchListener->missedDirectory.clear();
+		}
+		m_DebouncedChanges.clear();
+		m_DebouncedRefreshPaths.clear();
+		m_AssetWatchMissedEvents = false;
+		m_AssetWatchMissedDirectory.clear();
+		m_AssetWatchClearSuppressionNextDrain = false;
+		if (assetRoot.empty())
+			return;
+
+		std::error_code ec;
+		const auto absoluteRoot = std::filesystem::absolute(assetRoot, ec).
+			lexically_normal();
+		if (ec)
+		{
+			m_LastStatusMsg = "Asset watcher root failed: " + ec.message();
+			printf("[FileWatcher] %s\n", m_LastStatusMsg.c_str());
+			return;
+		}
+		std::vector<efsw::WatcherOption> options;
+		if (!IsNetworkWatchRoot(absoluteRoot))
+			options.emplace_back(efsw::Options::WinBufferSize,
+				static_cast<int>(rt2::core::AssetWatchBufferSize(
+					rt2::core::AssetWatchDriveKind::Local)));
+		const auto watchId = m_FileWatcher->addWatch(
+			absoluteRoot.u8string(), m_FileWatchListener.get(), true, options);
+		if (watchId < 0)
+		{
+			printf("[FileWatcher] assetRoot addWatch failed for \"%s\" (id=%d)\n",
+				absoluteRoot.u8string().c_str(), static_cast<int>(watchId));
+			m_LastStatusMsg = "Asset watcher failed to start";
+			return;
+		}
+		m_ActiveWatchId = watchId;
+		printf("[FileWatcher] watching assetRoot \"%s\" recursively\n",
+			absoluteRoot.u8string().c_str());
 	}
 
 	bool RefreshProjectAssets()
@@ -3548,12 +3801,14 @@ public:
 				printf("[Project] %s\n", m_LastStatusMsg.c_str());
 				return;
 			}
+			ConfigureAssetRootWatch(staged->project.assetRoot);
 			m_ProjectContext = staged;
 			NewSceneInternal();
 			ApplyActiveInputConfiguration();
 			m_LastStatusMsg = "Project opened (no startup scene)";
 			return;
 		}
+		ConfigureAssetRootWatch(staged->project.assetRoot);
 		OpenRt2SceneInternal(
 			scenePath.u8string(), staged);
 	}
@@ -3708,6 +3963,9 @@ public:
 			if (!success)
 			{
 				printf("[Scene] %s\n", errorStr->c_str());
+				ConfigureAssetRootWatch(m_ProjectContext
+					? m_ProjectContext->project.assetRoot
+					: std::filesystem::path{});
 				ImGui::OpenPopup("Scene Load Failed");
 				m_LastStatusMsg = *errorStr;
 				return;
@@ -3723,72 +3981,11 @@ public:
 			m_EditorUI.ResetForDocument();
 			if (m_InspectorFieldRegistry) m_InspectorFieldRegistry->Clear();
 
-			// Phase 6C/W2: watch directories containing referenced
-			// script assets for .lua file changes. The scene's parent
-			// directory covers scene-relative scripts; we also walk
-			// every ScriptComponent to catch absolute paths or shared
-			// script folders outside the scene tree. All watches are
-			// recursive and deduped by directory path.
-			if (m_FileWatcher && m_FileWatchListener)
-			{
-				for (efsw::WatchID wid : m_ActiveWatchIds)
-					m_FileWatcher->removeWatch(wid);
-				m_ActiveWatchIds.clear();
-
-				std::set<std::string> dirs;
-				const auto sceneDir =
-					rt2::core::ScriptWatchDirectoryForCandidate(
-						std::filesystem::path(filepathCopy));
-				if (!sceneDir.empty())
-					dirs.insert(sceneDir.string());
-
-				auto& doc = m_SceneMgr.AuthoringDoc();
-				m_ScriptAssetContext = assetContext;
-				m_ScriptAssetDiagnostics.clear();
-				auto view = doc.ecs.registry.view<ScriptComponent>();
-				for (auto e : view)
-				{
-					const auto& sc = view.get<ScriptComponent>(e);
-					const auto* id =
-						doc.ecs.registry.try_get<EntityIdComponent>(e);
-					const auto* name =
-						doc.ecs.registry.try_get<NameComponent>(e);
-					const size_t diagnosticBase =
-						m_ScriptAssetDiagnostics.size();
-					auto resolved = rt2::core::ResolveScriptAssetPath(
-						sc, m_ScriptAssetContext,
-						id ? id->id : rt2::core::UUID::Nil(),
-						name ? name->name : std::string{},
-						m_ScriptAssetDiagnostics);
-					std::filesystem::path watchPath =
-						resolved.resolvedPath;
-					if (watchPath.empty() &&
-						m_ScriptAssetDiagnostics.size() > diagnosticBase)
-					{
-						watchPath = m_ScriptAssetDiagnostics.back().
-							resolvedPath;
-					}
-					const auto parent =
-						rt2::core::ScriptWatchDirectoryForCandidate(
-							watchPath);
-					if (!parent.empty())
-						dirs.insert(parent.string());
-				}
-				LogScriptAssetDiagnostics(0, "FileWatcher");
-
-				for (const auto& dir : dirs)
-				{
-					efsw::WatchID wid =
-						m_FileWatcher->addWatch(dir,
-							m_FileWatchListener.get(), true);
-					if (wid < 0)
-						printf("[FileWatcher] addWatch failed for "
-							"\"%s\" (id=%d)\n", dir.c_str(),
-							static_cast<int>(wid));
-					else
-						m_ActiveWatchIds.push_back(wid);
-				}
-			}
+			// W7 watches the project asset root, not directories inferred from
+			// the currently open scene. Standalone scenes have no active watch.
+			ConfigureAssetRootWatch(projectSnapshot
+				? projectSnapshot->project.assetRoot
+				: std::filesystem::path{});
 
 			m_History.Clear();
 			CompactMeshRegistryNowAsserted();

--- a/RT2Tests/RT2Tests.vcxproj
+++ b/RT2Tests/RT2Tests.vcxproj
@@ -306,6 +306,9 @@
     <ClCompile Include="..\RT2App\src\ContentBrowserOperations.cpp">
       <ExternalWarningLevel>Level3</ExternalWarningLevel>
     </ClCompile>
+    <ClCompile Include="..\RT2App\src\AssetWatchPolicy.cpp">
+      <ExternalWarningLevel>Level3</ExternalWarningLevel>
+    </ClCompile>
     <ClCompile Include="..\RT2App\src\SceneVisibility.cpp">
       <ExternalWarningLevel>Level3</ExternalWarningLevel>
       <ExternalWarningLevel>Level3</ExternalWarningLevel>
@@ -700,6 +703,9 @@
       <ExternalWarningLevel>Level3</ExternalWarningLevel>
     </ClCompile>
     <ClCompile Include="src\Phase7W6Tests.cpp">
+      <ExternalWarningLevel>Level3</ExternalWarningLevel>
+    </ClCompile>
+    <ClCompile Include="src\Phase7W7Tests.cpp">
       <ExternalWarningLevel>Level3</ExternalWarningLevel>
     </ClCompile>
     <ClCompile Include="src\RecoveryTests.cpp">

--- a/RT2Tests/src/Phase7W6Tests.cpp
+++ b/RT2Tests/src/Phase7W6Tests.cpp
@@ -22,6 +22,7 @@ namespace {
 const UUID kModelId = UUID::Parse("550e8400-e29b-41d4-a716-446655440101");
 const UUID kScriptId = UUID::Parse("550e8400-e29b-41d4-a716-446655440102");
 const UUID kEntityId = UUID::Parse("550e8400-e29b-41d4-a716-446655440103");
+const UUID kOtherEntityId = UUID::Parse("550e8400-e29b-41d4-a716-446655440104");
 
 struct TempTree
 {
@@ -314,6 +315,99 @@ TEST_CASE("Phase7 W6 dependants come from live scene references")
     CHECK(scriptDependants[0].entityUuid == kEntityId);
     CHECK(scriptDependants[0].entityName == "Hero");
     CHECK(scriptDependants[0].kind == AssetKind::Script);
+}
+
+TEST_CASE("Phase7 W6 dependants match nil-ID references by path")
+{
+    TempTree tree;
+    SceneDocument document;
+    const auto entity = document.ecs.registry.create();
+    REQUIRE(document.AssignKnownUuid(entity, kEntityId));
+    document.ecs.registry.emplace<NameComponent>(entity, "LegacyHero");
+    ImportedMeshSourceComponent imported;
+    imported.model.kind = AssetKind::Model;
+    imported.model.path = "models/hero.glb";
+    imported.model.sourceKey = "gltf:scene=0";
+    imported.model.assetId = UUID::Nil();
+    document.ecs.registry.emplace<ImportedMeshSourceComponent>(entity, imported);
+
+    const auto dependants = FindContentBrowserDependants(
+        document, Record("models/hero.glb", kModelId), tree.assets);
+    REQUIRE(dependants.size() == 1);
+    CHECK(dependants[0].entityUuid == kEntityId);
+    CHECK(dependants[0].sourcePath == "models/hero.glb");
+}
+
+TEST_CASE("Phase7 W6 dependants do not match nil-ID references by a different path")
+{
+    TempTree tree;
+    SceneDocument document;
+    const auto entity = document.ecs.registry.create();
+    REQUIRE(document.AssignKnownUuid(entity, kEntityId));
+    ImportedMeshSourceComponent imported;
+    imported.model.kind = AssetKind::Model;
+    imported.model.path = "models/other.glb";
+    imported.model.sourceKey = "gltf:scene=0";
+    imported.model.assetId = UUID::Nil();
+    document.ecs.registry.emplace<ImportedMeshSourceComponent>(entity, imported);
+
+    const auto dependants = FindContentBrowserDependants(
+        document, Record("models/hero.glb", kModelId), tree.assets);
+    CHECK(dependants.empty());
+}
+
+TEST_CASE("Phase7 W6 dependants report same-path references with a conflicting ID")
+{
+    TempTree tree;
+    SceneDocument document;
+    const auto entity = document.ecs.registry.create();
+    REQUIRE(document.AssignKnownUuid(entity, kEntityId));
+    ImportedMeshSourceComponent imported;
+    imported.model.kind = AssetKind::Model;
+    imported.model.path = "models/hero.glb";
+    imported.model.sourceKey = "gltf:scene=0";
+    imported.model.assetId = kScriptId;
+    document.ecs.registry.emplace<ImportedMeshSourceComponent>(entity, imported);
+
+    // The query is a destructive-action warning, so same-path disagreement
+    // is reported rather than silently trusting the conflicting identity.
+    const auto dependants = FindContentBrowserDependants(
+        document, Record("models/hero.glb", kModelId), tree.assets);
+    REQUIRE(dependants.size() == 1);
+    CHECK(dependants[0].entityUuid == kEntityId);
+}
+
+TEST_CASE("Phase7 W6 dependants report mixed ID and legacy references")
+{
+    TempTree tree;
+    SceneDocument document;
+    const auto withId = document.ecs.registry.create();
+    REQUIRE(document.AssignKnownUuid(withId, kEntityId));
+    document.ecs.registry.emplace<NameComponent>(withId, "ImportedHero");
+    ImportedMeshSourceComponent imported;
+    imported.model.kind = AssetKind::Model;
+    imported.model.path = "models/hero.glb";
+    imported.model.sourceKey = "gltf:scene=0";
+    imported.model.assetId = kModelId;
+    document.ecs.registry.emplace<ImportedMeshSourceComponent>(withId, imported);
+
+    const auto legacy = document.ecs.registry.create();
+    REQUIRE(document.AssignKnownUuid(legacy, kOtherEntityId));
+    document.ecs.registry.emplace<NameComponent>(legacy, "LegacyHero");
+    ImportedMeshSourceComponent legacyImported;
+    legacyImported.model.kind = AssetKind::Model;
+    legacyImported.model.path = "models/hero.glb";
+    legacyImported.model.sourceKey = "gltf:scene=1";
+    legacyImported.model.assetId = UUID::Nil();
+    document.ecs.registry.emplace<ImportedMeshSourceComponent>(legacy, legacyImported);
+
+    const auto dependants = FindContentBrowserDependants(
+        document, Record("models/hero.glb", kModelId), tree.assets);
+    REQUIRE(dependants.size() == 2);
+    CHECK(std::all_of(dependants.begin(), dependants.end(),
+        [](const ContentBrowserDependant& dependant) {
+            return dependant.sourcePath == "models/hero.glb";
+        }));
 }
 
 TEST_CASE("Phase7 W6 reimport dispatch preserves sidecar identity")

--- a/RT2Tests/src/Phase7W7Tests.cpp
+++ b/RT2Tests/src/Phase7W7Tests.cpp
@@ -4,7 +4,9 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <fstream>
 #include <mutex>
+#include <sstream>
 #include <string>
 
 using namespace rt2::core;
@@ -20,6 +22,26 @@ AssetFileAction kActions[] = {
     AssetFileAction::Delete,
     AssetFileAction::Moved,
 };
+
+std::string WalnutAppSource()
+{
+    std::ifstream input("RT2App/src/WalnutApp.cpp");
+    REQUIRE(input.good());
+    std::ostringstream contents;
+    contents << input.rdbuf();
+    return contents.str();
+}
+
+std::string SourceSlice(const std::string& source,
+                        const std::string& begin,
+                        const std::string& end)
+{
+    const auto beginAt = source.find(begin);
+    REQUIRE(beginAt != std::string::npos);
+    const auto endAt = source.find(end, beginAt + begin.size());
+    REQUIRE(endAt != std::string::npos);
+    return source.substr(beginAt, endAt - beginAt);
+}
 
 } // namespace
 
@@ -91,6 +113,23 @@ TEST_CASE("Phase7 W7 event queue coalesces and truncates by path")
     CHECK(updated->action == AssetFileAction::Delete);
 }
 
+TEST_CASE("Phase7 W7 repeated events for one path have one queued refresh")
+{
+    AssetWatchEventQueue queue;
+    for (size_t i = 0; i < kAssetWatchQueueLimit; ++i)
+        REQUIRE(queue.Enqueue(kRoot / "model.glb", AssetFileAction::Modified));
+    const auto events = queue.Drain();
+    REQUIRE(events.size() == 1);
+    CHECK(events.front().refreshDatabase);
+}
+
+TEST_CASE("Phase7 W7 watcher buffer and debounce policy are explicit")
+{
+    CHECK(AssetWatchBufferSize(AssetWatchDriveKind::Local) == 256u * 1024u);
+    CHECK(AssetWatchBufferSize(AssetWatchDriveKind::Network) == 63u * 1024u);
+    CHECK(kAssetWatchDebounceMilliseconds == 100);
+}
+
 TEST_CASE("Phase7 W7 refresh decision queues while busy and refreshes after")
 {
     CHECK(DecideWatchRefreshAction(false, 0, false) ==
@@ -126,4 +165,130 @@ TEST_CASE("Phase7 W7 shared mutex makes suppression and enqueue atomic")
     // The host checks suppression before enqueue; this queue call models the
     // subsequent publication while the same mutex is still held.
     CHECK(queue.SizeLocked() == 1);
+}
+
+TEST_CASE("Phase7 W7 host checks suppression before publishing watcher events")
+{
+    const auto source = WalnutAppSource();
+    const auto listener = SourceSlice(
+        source, "class AssetWatchListener", "// Declaration order matters");
+    CHECK(listener.find("IsSuppressedLocked") != std::string::npos);
+    CHECK(listener.find("EnqueueLocked") != std::string::npos);
+    CHECK(listener.find("handleMissedFileActions") != std::string::npos);
+    CHECK(listener.find("ResolveOrAssign") == std::string::npos);
+}
+
+TEST_CASE("Phase7 W7 host drains duplicate asset paths through one refresh")
+{
+    const auto source = WalnutAppSource();
+    const auto drain = SourceSlice(
+        source, "void DrainAssetWatchChanges", "bool IsNetworkWatchRoot");
+    CHECK(drain.find("std::find(m_DebouncedRefreshPaths.begin()") !=
+          std::string::npos);
+    CHECK(drain.find("RefreshProjectAssets();") != std::string::npos);
+    CHECK(drain.find("kAssetWatchQueueLimit") != std::string::npos);
+}
+
+TEST_CASE("Phase7 W7 host queues watcher events during background work")
+{
+    const auto source = WalnutAppSource();
+    const auto drain = SourceSlice(
+        source, "void DrainAssetWatchChanges", "bool IsNetworkWatchRoot");
+    CHECK(drain.find("DecideWatchRefreshAction") != std::string::npos);
+    CHECK(drain.find("AssetWatchRefreshAction::Queue") != std::string::npos);
+    CHECK(source.find("m_BackgroundWork.reset();") != std::string::npos);
+    CHECK(source.find("DrainAssetWatchChanges(true);") != std::string::npos);
+}
+
+TEST_CASE("Phase7 W7 missed watcher events force an immediate host refresh")
+{
+    const auto source = WalnutAppSource();
+    const auto listener = SourceSlice(
+        source, "class AssetWatchListener", "// Declaration order matters");
+    const auto drain = SourceSlice(
+        source, "void DrainAssetWatchChanges", "bool IsNetworkWatchRoot");
+    CHECK(listener.find("handleMissedFileActions") != std::string::npos);
+    CHECK(listener.find("missedEvents = true") != std::string::npos);
+    CHECK(drain.find("File system events may have been missed") !=
+          std::string::npos);
+    CHECK(drain.find("m_AssetWatchMissedEvents") != std::string::npos);
+}
+
+TEST_CASE("Phase7 W7 watcher scope is project assetRoot only")
+{
+    const auto source = WalnutAppSource();
+    CHECK(source.find("ConfigureAssetRootWatch(staged->project.assetRoot)") !=
+          std::string::npos);
+    CHECK(source.find("std::optional<efsw::WatchID>") != std::string::npos);
+    CHECK(source.find("m_ActiveWatchId") != std::string::npos);
+    CHECK(source.find("ScriptWatchDirectoryForCandidate") == std::string::npos);
+}
+
+TEST_CASE("Phase7 W7 watcher never performs identity assignment")
+{
+    const auto source = WalnutAppSource();
+    const auto drain = SourceSlice(
+        source, "void DrainAssetWatchChanges", "bool IsNetworkWatchRoot");
+    CHECK(drain.find("ResolveOrAssign") == std::string::npos);
+    CHECK(drain.find("RefreshProjectAssets") != std::string::npos);
+}
+
+TEST_CASE("Phase7 W7 scene files stay outside automatic reload policy")
+{
+    for (const auto action : kActions)
+        CHECK(ClassifyAssetFileEvent(kRoot / "open.rt2scene", action) ==
+              AssetFileEventKind::Ignore);
+    const auto source = WalnutAppSource();
+    CHECK(source.find("ConfigureAssetRootWatch") != std::string::npos);
+    CHECK(source.find("OpenRt2SceneInternal") != std::string::npos);
+}
+
+TEST_CASE("Phase7 W7 W6 operations register source sidecar and destinations")
+{
+    AssetWatchSuppressionRegistry registry;
+    const auto source = kRoot / "model.glb";
+    const auto sidecar = source.string() + ".rt2meta";
+    const auto destination = kRoot / "moved" / "model.glb";
+    registry.RegisterMany({source, sidecar, destination,
+                           destination.string() + ".rt2meta"});
+    CHECK(registry.IsSuppressed(source));
+    CHECK(registry.IsSuppressed(sidecar));
+    CHECK(registry.IsSuppressed(destination));
+    CHECK(registry.IsSuppressed(destination.string() + ".rt2meta"));
+
+    const auto app = WalnutAppSource();
+    CHECK(app.find("RegisterAssetWatchPaths") != std::string::npos);
+    CHECK(app.find("ScheduleAssetWatchSuppressionClear") !=
+          std::string::npos);
+}
+
+TEST_CASE("Phase7 W7 local and network watcher buffers are distinct")
+{
+    CHECK(AssetWatchBufferSize(AssetWatchDriveKind::Local) == 256u * 1024u);
+    CHECK(AssetWatchBufferSize(AssetWatchDriveKind::Network) == 63u * 1024u);
+    const auto source = WalnutAppSource();
+    CHECK(source.find("DRIVE_REMOTE") != std::string::npos);
+    CHECK(source.find("Options::WinBufferSize") != std::string::npos);
+}
+
+TEST_CASE("Phase7 W7 atomic save events retain the debounce window")
+{
+    AssetWatchEventQueue queue;
+    REQUIRE(queue.Enqueue(kRoot / "script.lua", AssetFileAction::Modified));
+    REQUIRE(queue.Enqueue(kRoot / "script.lua", AssetFileAction::Add));
+    REQUIRE(queue.Enqueue(kRoot / "script.lua", AssetFileAction::Delete));
+    CHECK(queue.Drain().size() == 1);
+    CHECK(kAssetWatchDebounceMilliseconds == 100);
+    const auto source = WalnutAppSource();
+    CHECK(source.find("kAssetWatchDebounceMilliseconds") != std::string::npos);
+}
+
+TEST_CASE("Phase7 W7 explicit Refresh remains available as a backstop")
+{
+    const auto source = WalnutAppSource();
+    CHECK(source.find("Refresh Assets") != std::string::npos);
+    CHECK(source.find("if (ImGui::Button(\"Refresh\"))") !=
+          std::string::npos);
+    CHECK(source.find("Asset change queue overflowed; use Refresh") !=
+          std::string::npos);
 }

--- a/RT2Tests/src/Phase7W7Tests.cpp
+++ b/RT2Tests/src/Phase7W7Tests.cpp
@@ -161,24 +161,55 @@ TEST_CASE("Phase7 W7 shared mutex makes suppression and enqueue atomic")
     std::lock_guard<std::mutex> lock(mutex);
     registry.RegisterLocked(path);
     CHECK(registry.IsSuppressedLocked(path));
-    CHECK(queue.EnqueueLocked(path, AssetFileAction::Modified));
-    // The host checks suppression before enqueue; this queue call models the
-    // subsequent publication while the same mutex is still held.
+    CHECK_FALSE(PublishAssetWatchEventLocked(
+        registry, queue, path, AssetFileAction::Modified));
+    CHECK(queue.SizeLocked() == 0);
+    registry.ClearLocked();
+    CHECK(PublishAssetWatchEventLocked(
+        registry, queue, path, AssetFileAction::Modified));
     CHECK(queue.SizeLocked() == 1);
 }
 
-TEST_CASE("Phase7 W7 host checks suppression before publishing watcher events")
+TEST_CASE("Phase7 W7 W6 operations register paths before filesystem callbacks")
 {
-    const auto source = WalnutAppSource();
-    const auto listener = SourceSlice(
-        source, "class AssetWatchListener", "// Declaration order matters");
-    CHECK(listener.find("IsSuppressedLocked") != std::string::npos);
-    CHECK(listener.find("EnqueueLocked") != std::string::npos);
-    CHECK(listener.find("handleMissedFileActions") != std::string::npos);
-    CHECK(listener.find("ResolveOrAssign") == std::string::npos);
+    const auto source = kRoot / "model.glb";
+    const auto destination = kRoot / "moved" / "model.glb";
+    struct OperationCase
+    {
+        AssetWatchOperationKind kind;
+        std::filesystem::path destination;
+        size_t expectedPathCount;
+    };
+    const std::vector<OperationCase> operations{
+        {AssetWatchOperationKind::Reimport, {}, 2},
+        {AssetWatchOperationKind::Rename, destination, 4},
+        {AssetWatchOperationKind::Move, destination, 4},
+        {AssetWatchOperationKind::Delete, {}, 2},
+    };
+
+    AssetWatchSuppressionRegistry registry;
+    for (const auto& operation : operations)
+    {
+        const auto expectedPaths = AssetWatchSuppressionPaths(
+            operation.kind, source, operation.destination);
+        REQUIRE(expectedPaths.size() == operation.expectedPathCount);
+        bool invoked = false;
+        bool unsuppressedEventObserved = false;
+        CHECK(RunSuppressedAssetOperation(
+            registry, operation.kind, source, operation.destination, [&]() {
+            invoked = true;
+            for (const auto& path : expectedPaths)
+                unsuppressedEventObserved =
+                    unsuppressedEventObserved || !registry.IsSuppressed(path);
+            return true;
+        }));
+        CHECK(invoked);
+        CHECK_FALSE(unsuppressedEventObserved);
+        registry.Clear();
+    }
 }
 
-TEST_CASE("Phase7 W7 host drains duplicate asset paths through one refresh")
+TEST_CASE("Phase7 W7 static check: host drains duplicate asset paths through one refresh")
 {
     const auto source = WalnutAppSource();
     const auto drain = SourceSlice(
@@ -189,7 +220,7 @@ TEST_CASE("Phase7 W7 host drains duplicate asset paths through one refresh")
     CHECK(drain.find("kAssetWatchQueueLimit") != std::string::npos);
 }
 
-TEST_CASE("Phase7 W7 host queues watcher events during background work")
+TEST_CASE("Phase7 W7 static check: host queues watcher events during background work")
 {
     const auto source = WalnutAppSource();
     const auto drain = SourceSlice(
@@ -200,7 +231,7 @@ TEST_CASE("Phase7 W7 host queues watcher events during background work")
     CHECK(source.find("DrainAssetWatchChanges(true);") != std::string::npos);
 }
 
-TEST_CASE("Phase7 W7 missed watcher events force an immediate host refresh")
+TEST_CASE("Phase7 W7 static check: missed watcher events force an immediate host refresh")
 {
     const auto source = WalnutAppSource();
     const auto listener = SourceSlice(
@@ -214,7 +245,7 @@ TEST_CASE("Phase7 W7 missed watcher events force an immediate host refresh")
     CHECK(drain.find("m_AssetWatchMissedEvents") != std::string::npos);
 }
 
-TEST_CASE("Phase7 W7 watcher scope is project assetRoot only")
+TEST_CASE("Phase7 W7 static check: watcher scope is project assetRoot only")
 {
     const auto source = WalnutAppSource();
     CHECK(source.find("ConfigureAssetRootWatch(staged->project.assetRoot)") !=
@@ -222,15 +253,6 @@ TEST_CASE("Phase7 W7 watcher scope is project assetRoot only")
     CHECK(source.find("std::optional<efsw::WatchID>") != std::string::npos);
     CHECK(source.find("m_ActiveWatchId") != std::string::npos);
     CHECK(source.find("ScriptWatchDirectoryForCandidate") == std::string::npos);
-}
-
-TEST_CASE("Phase7 W7 watcher never performs identity assignment")
-{
-    const auto source = WalnutAppSource();
-    const auto drain = SourceSlice(
-        source, "void DrainAssetWatchChanges", "bool IsNetworkWatchRoot");
-    CHECK(drain.find("ResolveOrAssign") == std::string::npos);
-    CHECK(drain.find("RefreshProjectAssets") != std::string::npos);
 }
 
 TEST_CASE("Phase7 W7 scene files stay outside automatic reload policy")
@@ -243,26 +265,16 @@ TEST_CASE("Phase7 W7 scene files stay outside automatic reload policy")
     CHECK(source.find("OpenRt2SceneInternal") != std::string::npos);
 }
 
-TEST_CASE("Phase7 W7 W6 operations register source sidecar and destinations")
+TEST_CASE("Phase7 W7 static check: watcher never performs identity assignment")
 {
-    AssetWatchSuppressionRegistry registry;
-    const auto source = kRoot / "model.glb";
-    const auto sidecar = source.string() + ".rt2meta";
-    const auto destination = kRoot / "moved" / "model.glb";
-    registry.RegisterMany({source, sidecar, destination,
-                           destination.string() + ".rt2meta"});
-    CHECK(registry.IsSuppressed(source));
-    CHECK(registry.IsSuppressed(sidecar));
-    CHECK(registry.IsSuppressed(destination));
-    CHECK(registry.IsSuppressed(destination.string() + ".rt2meta"));
-
-    const auto app = WalnutAppSource();
-    CHECK(app.find("RegisterAssetWatchPaths") != std::string::npos);
-    CHECK(app.find("ScheduleAssetWatchSuppressionClear") !=
-          std::string::npos);
+    const auto source = WalnutAppSource();
+    const auto drain = SourceSlice(
+        source, "void DrainAssetWatchChanges", "bool IsNetworkWatchRoot");
+    CHECK(drain.find("ResolveOrAssign") == std::string::npos);
+    CHECK(drain.find("RefreshProjectAssets") != std::string::npos);
 }
 
-TEST_CASE("Phase7 W7 local and network watcher buffers are distinct")
+TEST_CASE("Phase7 W7 static check: local and network watcher buffers are distinct")
 {
     CHECK(AssetWatchBufferSize(AssetWatchDriveKind::Local) == 256u * 1024u);
     CHECK(AssetWatchBufferSize(AssetWatchDriveKind::Network) == 63u * 1024u);
@@ -271,7 +283,7 @@ TEST_CASE("Phase7 W7 local and network watcher buffers are distinct")
     CHECK(source.find("Options::WinBufferSize") != std::string::npos);
 }
 
-TEST_CASE("Phase7 W7 atomic save events retain the debounce window")
+TEST_CASE("Phase7 W7 static check: atomic save events retain the debounce window")
 {
     AssetWatchEventQueue queue;
     REQUIRE(queue.Enqueue(kRoot / "script.lua", AssetFileAction::Modified));
@@ -283,7 +295,7 @@ TEST_CASE("Phase7 W7 atomic save events retain the debounce window")
     CHECK(source.find("kAssetWatchDebounceMilliseconds") != std::string::npos);
 }
 
-TEST_CASE("Phase7 W7 explicit Refresh remains available as a backstop")
+TEST_CASE("Phase7 W7 static check: explicit Refresh remains available as a backstop")
 {
     const auto source = WalnutAppSource();
     CHECK(source.find("Refresh Assets") != std::string::npos);

--- a/RT2Tests/src/Phase7W7Tests.cpp
+++ b/RT2Tests/src/Phase7W7Tests.cpp
@@ -1,0 +1,129 @@
+#include <doctest/doctest.h>
+
+#include "AssetWatchPolicy.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <mutex>
+#include <string>
+
+using namespace rt2::core;
+
+namespace {
+
+const std::filesystem::path kRoot =
+    std::filesystem::absolute("phase7-w7-watch-root");
+
+AssetFileAction kActions[] = {
+    AssetFileAction::Add,
+    AssetFileAction::Modified,
+    AssetFileAction::Delete,
+    AssetFileAction::Moved,
+};
+
+} // namespace
+
+TEST_CASE("Phase7 W7 classifies supported asset events by extension")
+{
+    for (const auto action : kActions)
+    {
+        CHECK(ClassifyAssetFileEvent(kRoot / "script.LUA", action) ==
+              AssetFileEventKind::ScriptReload);
+        CHECK(ClassifyAssetFileEvent(kRoot / "model.glb", action) ==
+              AssetFileEventKind::DatabaseRefresh);
+        CHECK(ClassifyAssetFileEvent(kRoot / "model.gltf", action) ==
+              AssetFileEventKind::DatabaseRefresh);
+        CHECK(ClassifyAssetFileEvent(kRoot / "model.obj", action) ==
+              AssetFileEventKind::DatabaseRefresh);
+        CHECK(ClassifyAssetFileEvent(kRoot / "sky.hdr", action) ==
+              AssetFileEventKind::DatabaseRefresh);
+        CHECK(ClassifyAssetFileEvent(kRoot / "sky.exr", action) ==
+              AssetFileEventKind::DatabaseRefresh);
+        CHECK(ClassifyAssetFileEvent(kRoot / "model.rt2meta", action) ==
+              AssetFileEventKind::DatabaseRefresh);
+        CHECK(ClassifyAssetFileEvent(kRoot / "scene.rt2scene", action) ==
+              AssetFileEventKind::Ignore);
+        CHECK(ClassifyAssetFileEvent(kRoot / "notes.txt", action) ==
+              AssetFileEventKind::Ignore);
+    }
+    CHECK(AssetFileNeedsDatabaseRefresh(
+        kRoot / "deleted.lua", AssetFileAction::Delete));
+    CHECK_FALSE(AssetFileNeedsDatabaseRefresh(
+        kRoot / "changed.lua", AssetFileAction::Modified));
+}
+
+TEST_CASE("Phase7 W7 suppression registry is normalized and clearable")
+{
+    AssetWatchSuppressionRegistry registry;
+    const auto source = kRoot / "models" / "hero.glb";
+    registry.Register(source);
+    registry.Register(source.lexically_normal());
+    CHECK(registry.Size() == 1);
+    CHECK(registry.IsSuppressed(source));
+    CHECK(registry.IsSuppressed(kRoot / "models" / "." / "hero.glb"));
+    CHECK_FALSE(registry.IsSuppressed(kRoot / "models" / "other.glb"));
+    registry.Clear();
+    CHECK(registry.Size() == 0);
+    CHECK_FALSE(registry.IsSuppressed(source));
+}
+
+TEST_CASE("Phase7 W7 event queue coalesces and truncates by path")
+{
+    AssetWatchEventQueue queue;
+    for (size_t i = 0; i < kAssetWatchQueueLimit; ++i)
+        REQUIRE(queue.Enqueue(kRoot / ("asset" + std::to_string(i) + ".glb"),
+                              AssetFileAction::Modified));
+    REQUIRE(queue.Size() == kAssetWatchQueueLimit);
+    REQUIRE(queue.Enqueue(kRoot / "asset42.glb", AssetFileAction::Delete));
+    CHECK(queue.Size() == kAssetWatchQueueLimit);
+    CHECK_FALSE(queue.TakeOverflowed());
+    REQUIRE(queue.Enqueue(kRoot / "newest.glb", AssetFileAction::Add));
+    CHECK(queue.Size() == kAssetWatchQueueLimit);
+    CHECK(queue.TakeOverflowed());
+    const auto events = queue.Drain();
+    REQUIRE(events.size() == kAssetWatchQueueLimit);
+    CHECK(events.back().path == NormalizeWatchPath(kRoot / "newest.glb"));
+    const auto updated = std::find_if(events.begin(), events.end(),
+        [](const AssetWatchEvent& event) {
+            return event.path.find("asset42.glb") != std::string::npos;
+        });
+    REQUIRE(updated != events.end());
+    CHECK(updated->action == AssetFileAction::Delete);
+}
+
+TEST_CASE("Phase7 W7 refresh decision queues while busy and refreshes after")
+{
+    CHECK(DecideWatchRefreshAction(false, 0, false) ==
+          AssetWatchRefreshAction::NoOp);
+    CHECK(DecideWatchRefreshAction(false, 1, true) ==
+          AssetWatchRefreshAction::Queue);
+    CHECK(DecideWatchRefreshAction(false, kAssetWatchQueueLimit, true) ==
+          AssetWatchRefreshAction::Truncate);
+    CHECK(DecideWatchRefreshAction(false, 1, false) ==
+          AssetWatchRefreshAction::RefreshNow);
+}
+
+TEST_CASE("Phase7 W7 missed events force a refresh when idle")
+{
+    CHECK(DecideWatchRefreshAction(true, 0, false) ==
+          AssetWatchRefreshAction::RefreshNow);
+    CHECK(DecideWatchRefreshAction(true, 1, false) ==
+          AssetWatchRefreshAction::RefreshNow);
+    CHECK(DecideWatchRefreshAction(true, 0, true) ==
+          AssetWatchRefreshAction::Queue);
+}
+
+TEST_CASE("Phase7 W7 shared mutex makes suppression and enqueue atomic")
+{
+    std::mutex mutex;
+    AssetWatchSuppressionRegistry registry(&mutex);
+    AssetWatchEventQueue queue(&mutex);
+    const auto path = kRoot / "models" / "hero.glb";
+    std::lock_guard<std::mutex> lock(mutex);
+    registry.RegisterLocked(path);
+    CHECK(registry.IsSuppressedLocked(path));
+    CHECK(queue.EnqueueLocked(path, AssetFileAction::Modified));
+    // The host checks suppression before enqueue; this queue call models the
+    // subsequent publication while the same mutex is still held.
+    CHECK(queue.SizeLocked() == 1);
+}

--- a/docs/game-engine-development-plan.md
+++ b/docs/game-engine-development-plan.md
@@ -10312,3 +10312,203 @@ check. `--recovery-scenario` passed, and `run_script_test.ps1` passed with 60
 frames, one entity, and no mismatches. The Release solution build completed
 successfully before the Release suite; the Debug solution build completed
 successfully before the Debug suite.
+
+## Phase 7 W7 verification report (2026-08-01)
+
+This report records the W7 discrimination pass against `3973e9c`. No
+production changes were retained; only this report is committed.
+
+### Measured gates
+
+The Release solution built successfully. Release `RT2Tests.exe` reported:
+
+```text
+[doctest] test cases:    732 |    732 passed | 0 failed | 0 skipped
+[doctest] assertions: 146428 | 146428 passed | 0 failed |
+[doctest] Status: SUCCESS!
+```
+
+The Debug solution built successfully. Debug `RT2Tests.exe` reported the same
+measured result: 732/732 test cases and 146428/146428 assertions, with status
+SUCCESS.
+
+The remaining gates passed:
+
+- `run_script_test.ps1`: `PASS: 60 frames, 1 entities, no mismatches`.
+- `run_slice_test.ps1`: `PASS: 60 steps, authoring intact`; final cube X
+  `0.999999702`.
+- `run_punctual_light_test.ps1`: `lit samples: 48, peak luminance: 42.7`,
+  `PASS`.
+- Release `--headless --validate` exited 0 with zero validation messages.
+  The existing CLI also reported that `--out artifacts/v.png` is unknown and
+  saved `screenshot.png`; this did not change the zero exit or validation
+  result.
+
+### Interactive acceptance
+
+The external `.lua` edit was performed while the editor was open; the Session
+panel reported `Scripts reloaded`, confirming hot reload.
+
+An asset was added externally and appeared after the automatic `Project assets
+refreshed` status. The same temporary asset was deleted externally; the
+Content Browser then showed `No matching assets` after the automatic refresh.
+
+The W6 rename exercise was attempted with the watcher active. The Content
+Browser context menu opened, but selecting `Rename...` did not open the rename
+modal, so no rename was actually performed and no end-to-end observation of a
+rename without a redundant scan was established. This remains an acceptance
+gap, not a claimed pass.
+
+### Discrimination proofs
+
+Each fault below was injected temporarily, followed by a Release build and
+the named test only; it was then reverted, rebuilt, and the named test passed.
+
+1. **`.glb` classified as `ScriptReload`.**
+
+   ```text
+   Phase7W7Tests.cpp(55): ERROR: CHECK( ClassifyAssetFileEvent(kRoot / "model.glb", action) == AssetFileEventKind::DatabaseRefresh ) is NOT correct!
+     values: CHECK( 2 == 1 )
+   ```
+   The error occurred four times. Summary: `38 assertions: 34 passed, 4
+   failed`. Reverted result: `1 passed`, `38/38` assertions.
+
+2. **Suppression check disabled in event publication.**
+
+   ```text
+   Phase7W7Tests.cpp(165): ERROR: CHECK_FALSE( PublishAssetWatchEventLocked( registry, queue, path, AssetFileAction::Modified) ) is NOT correct!
+     values: CHECK_FALSE( true )
+   Phase7W7Tests.cpp(166): ERROR: CHECK( queue.SizeLocked() == 0 ) is NOT correct!
+     values: CHECK( 1 == 0 )
+   ```
+   Summary: `5 assertions: 3 passed, 2 failed`. Reverted result: `1 passed`,
+   `5/5` assertions.
+
+3. **Path deduplication removed.**
+
+   ```text
+   Phase7W7Tests.cpp(122): FATAL ERROR: REQUIRE( events.size() == 1 ) is NOT correct!
+     values: REQUIRE( 100 == 1 )
+   ```
+   Summary: `101 assertions: 100 passed, 1 failed`. Reverted result: `1
+   passed`, `102/102` assertions.
+
+4. **Busy watcher events dropped instead of queued.**
+
+   ```text
+   Phase7W7Tests.cpp(138): ERROR: CHECK( DecideWatchRefreshAction(false, 1, true) == AssetWatchRefreshAction::Queue ) is NOT correct!
+     values: CHECK( 0 == 2 )
+   Phase7W7Tests.cpp(140): ERROR: CHECK( DecideWatchRefreshAction(false, kAssetWatchQueueLimit, true) == AssetWatchRefreshAction::Truncate ) is NOT correct!
+     values: CHECK( 0 == 3 )
+   ```
+   Summary: `4 assertions: 2 passed, 2 failed`. Reverted result: `1 passed`,
+   `4/4` assertions.
+
+5. **Missed-event handler left as a no-op.**
+
+   ```text
+   Phase7W7Tests.cpp(148): ERROR: CHECK( DecideWatchRefreshAction(true, 0, false) == AssetWatchRefreshAction::RefreshNow ) is NOT correct!
+     values: CHECK( 0 == 1 )
+   ```
+   Summary: `3 assertions: 2 passed, 1 failed`. Reverted result: `1 passed`,
+   `3/3` assertions.
+
+6. **Watcher performs identity assignment.**
+
+   ```text
+   Phase7W7Tests.cpp(273): ERROR: CHECK( drain.find("ResolveOrAssign") == std::string::npos ) is NOT correct!
+     values: CHECK( 2662 == 18446744073709551615 )
+   ```
+   Summary: `5 assertions: 4 passed, 1 failed`. Reverted result: `1 passed`,
+   `5/5` assertions.
+
+7. **Watcher scope widened to the script-candidate walk.**
+
+   ```text
+   Phase7W7Tests.cpp(255): ERROR: CHECK( source.find("ScriptWatchDirectoryForCandidate") == std::string::npos ) is NOT correct!
+     values: CHECK( 140005 == 18446744073709551615 )
+   ```
+   Summary: `5 assertions: 4 passed, 1 failed`. Reverted result: `1 passed`,
+   `5/5` assertions.
+
+8. **`.rt2scene` classified as `DatabaseRefresh`.**
+
+   ```text
+   Phase7W7Tests.cpp(262): ERROR: CHECK( ClassifyAssetFileEvent(kRoot / "open.rt2scene", action) == AssetFileEventKind::Ignore ) is NOT correct!
+     values: CHECK( 1 == 2 )
+   ```
+   The error occurred four times. Summary: `7 assertions: 3 passed, 4
+   failed`. Reverted result: `1 passed`, `7/7` assertions.
+
+9. **Destination sidecar omitted from W6 suppression paths.**
+
+   ```text
+   Phase7W7Tests.cpp(195): FATAL ERROR: REQUIRE( expectedPaths.size() == operation.expectedPathCount ) is NOT correct!
+     values: REQUIRE( 3 == 4 )
+   ```
+   Summary: `5 assertions: 4 passed, 1 failed`. Reverted result: `1 passed`,
+   `16/16` assertions.
+
+10. **Network watcher buffer widened to 256 KiB.**
+
+   ```text
+   Phase7W7Tests.cpp(129): ERROR: CHECK( AssetWatchBufferSize(AssetWatchDriveKind::Network) == 63u * 1024u ) is NOT correct!
+     values: CHECK( 262144 == 64512 )
+   ```
+   Summary: `3 assertions: 2 passed, 1 failed`. Reverted result: `1 passed`,
+   `3/3` assertions.
+
+11. **Debounce window removed.**
+
+   ```text
+   Phase7W7Tests.cpp(293): ERROR: CHECK( kAssetWatchDebounceMilliseconds == 100 ) is NOT correct!
+     values: CHECK( 0 == 100 )
+   ```
+   Summary: `7 assertions: 6 passed, 1 failed`. Reverted result: `1 passed`,
+   `7/7` assertions.
+
+12. **Explicit Refresh label/backstop removed.**
+
+   ```text
+   Phase7W7Tests.cpp(301): ERROR: CHECK( source.find("Refresh Assets") != std::string::npos ) is NOT correct!
+     values: CHECK( 18446744073709551615 != 18446744073709551615 )
+   ```
+   Summary: `4 assertions: 3 passed, 1 failed`. Reverted result: `1 passed`,
+   `4/4` assertions.
+
+The two critical proofs were run before this pass. Registering suppression
+paths after the callback produced:
+
+```text
+Phase7W7Tests.cpp(207): ERROR: CHECK_FALSE( unsuppressedEventObserved ) is NOT correct!
+  values: CHECK_FALSE( true )
+[doctest] test cases: 1 | 0 passed | 1 failed | 731 skipped
+[doctest] assertions: 16 | 12 passed | 4 failed |
+```
+
+The same test was green after reverting: `1 passed`, `16/16` assertions.
+Commenting out a literal `RunAssetWatchSuppressedOperation` call in
+`WalnutApp.cpp` stayed green: `1 passed`, `16/16` assertions. That fault was
+restored and was not counted as a protective proof.
+
+### Known host-dispatch limitation
+
+The seam's ordering contract is proven by the behavioural test. The host's use
+of the seam is not proven, because `RT2Tests` compiles no RT2App sources and
+does not include `WalnutApp.cpp`. Commenting out one of the four host calls
+(`WalnutApp.cpp:1288`, `:1358`, `:1403`, or `:1447`) leaves the suite green.
+
+If that host wiring regresses, suppression fails and a W6 rename triggers a
+redundant scan. `RefreshProjectAssets` is transactional and read-only, so the
+consequence is wasted work, not corruption or data loss. The same gap exists
+for W5's `ShouldCaptureRecoverySnapshot` and W6's `ContentBrowserCanOperate`.
+Closing it requires extracting host dispatch into the CPU module; that work is
+deliberately out of scope for W7.
+
+The remaining tests named `static check: ...` are source-text guardrails for
+host wiring and configuration: duplicate-path drain, busy queueing, missed
+events, watcher scope, identity non-minting, buffer configuration, debounce,
+and explicit Refresh. They are useful regression checks but are not behavioural
+proofs of the host call sites. The CPU behavioural tests are the evidence for
+classification, suppression publication, queue coalescing, busy decisions,
+missed-event decisions, scene exclusion, and W6 suppression-path composition.

--- a/docs/game-engine-development-plan.md
+++ b/docs/game-engine-development-plan.md
@@ -10512,3 +10512,31 @@ and explicit Refresh. They are useful regression checks but are not behavioural
 proofs of the host call sites. The CPU behavioural tests are the evidence for
 classification, suppression publication, queue coalescing, busy decisions,
 missed-event decisions, scene exclusion, and W6 suppression-path composition.
+
+### W7 follow-up — content-browser popup scope (2026-08-01)
+
+The W6 content-browser UI had a popup-scope defect in `RT2App/src/WalnutApp.cpp`:
+Rename, Move, and Delete called `OpenPopup` inside each record's per-record
+and context-popup ID scopes, while their `BeginPopupModal` calls ran outside
+both scopes. The CPU operations were fully tested, but all three UI paths were
+unreachable. The fix captures `openRename`, `openMove`, and `openDelete` inside
+the loop and opens the matching popups after the loop beside the modal bodies.
+No modal body, suppression wiring, or CPU operation was changed.
+
+Interactive acceptance with the watcher active then showed:
+
+- Rename opened, changed `cube.obj` to `cube_renamed.obj`, retained its
+  sidecar identity, showed `Status: Asset renamed`, and did not show a
+  redundant project-refresh status.
+- Move opened, moved the renamed asset into `phase1a-fixtures`, showed
+  `Status: Asset moved`, and did not show a redundant project-refresh status.
+  The asset was then moved back for cleanup.
+- Delete opened for `script-scenario.lua`, which is referenced by the open
+  scene. The warning and confirmation controls appeared, so deletion required
+  explicit confirmation. The upper part of this modal was clipped off-screen,
+  preventing the dependant list from being fully observed; no deletion was
+  confirmed. This is a remaining UI defect.
+
+Release and Debug both measured 732/732 tests and 146428/146428 assertions;
+script, slice, and `--validate` gates passed. The host-dispatch extraction gap
+described above remains out of scope.

--- a/docs/game-engine-development-plan.md
+++ b/docs/game-engine-development-plan.md
@@ -10540,3 +10540,48 @@ Interactive acceptance with the watcher active then showed:
 Release and Debug both measured 732/732 tests and 146428/146428 assertions;
 script, slice, and `--validate` gates passed. The host-dispatch extraction gap
 described above remains out of scope.
+
+## 2026-08-02 — W7/W6 interactive dependant-query follow-up
+
+Interactive acceptance found a third W6 defect after the unopenable modals and
+the clipped confirmation dialog. `FindContentBrowserDependants`
+(`RT2App/src/ContentBrowserOperations.cpp:407-434`) gated `matchesPath` on
+the database record having a nil ID, but scanned records always carry a
+non-nil sidecar ID (`ProjectAssetScanner.cpp:210-216`). Path fallback was
+therefore unreachable for unmigrated v3 scene references. The safety
+consequence was material: the delete warning could claim there were no
+dependants, even though `ContentBrowserDeleteAllowed` does not block deletion
+(`ContentBrowserOperations.cpp:383-389`) and the list is the only warning
+mechanism.
+
+The fix makes ID matching require two non-nil, equal IDs, then uses the
+canonical source path whenever the ID match fails. Because this is an
+advisory destructive-action query rather than the resolver, same-path
+references with a conflicting ID are reported instead of being silently
+trusted. Four CPU-only tests cover nil-ID path matching, different-path
+non-matching, conflicting-ID same-path reporting, and mixed legacy/current
+references (`RT2Tests/src/Phase7W6Tests.cpp:319-412`).
+
+The delete acceptance was repeated in the editor with a temporary project
+fixture and temporary asset, both restored afterwards. A legacy script scene
+reference produced a readable one-entry dependant list; pressing Delete with
+the confirmation checkbox clear left the modal open. An unreferenced asset
+produced the compact modal with the checkbox and buttons visible. Deleting a
+temporary unreferenced asset with the watcher active removed it from the
+browser and showed `Asset deleted`; after the debounce interval there was no
+second `Project assets refreshed` status, so the delete suppression path did
+not trigger a redundant refresh.
+
+This is the third W6 defect found only through interactive acceptance while
+the CPU operations remained green throughout. It is further evidence that the
+host-dispatch extraction should land before more UI-heavy work: the CPU seam
+was correct enough to test, but the real modal and host integration were not
+observable from `RT2Tests` alone.
+
+Final verification after the fix measured 736/736 tests and 146453/146453
+assertions in both Release and Debug. Release and Debug builds passed;
+`run_script_test.ps1` passed its 60-frame scenario; `run_slice_test.ps1`
+passed its 60-step authoring-preservation scenario; and the Release headless
+`--validate` run exited 0 with no validation messages. The headless CLI still
+prints its pre-existing `--out` unknown-argument notice and saves its default
+`screenshot.png`; this follow-up did not change that behavior.

--- a/docs/game-engine-development-plan.md
+++ b/docs/game-engine-development-plan.md
@@ -8613,7 +8613,7 @@ The earlier deferrals remain real, but their landing workstream matters:
 | Source | Commitment | W4/W5 treatment |
 |---|---|---|
 | `docs/game-engine-development-plan.md:985` | Migrate to global asset UUIDs. | W5 closes the legacy-scene half by assigning/reusing sidecar IDs and persisting them in v4. |
-| `:3311,3380` | Input rebinding dialog. | W4 provides project defaults, user overrides and composition; W8 owns UI. |
+| `:3389-3390,3458-3459` | Input rebinding dialog. | W4 provides project defaults, user overrides and composition; W8 owns UI. |
 | `:4064,5274` | Script asset Rebind button. | No W4/W5 UI. W4/W5 make the underlying ID/path context stable; W8 owns the button. |
 | `:5521` | Declaration diagnostics in content browser. | W6/W8; no browser exists yet. |
 | `:5901` | Cursor-lock binding. | W4’s composition supports it later; W8 authors it. |
@@ -10585,3 +10585,353 @@ passed its 60-step authoring-preservation scenario; and the Release headless
 `--validate` run exited 0 with no validation messages. The headless CLI still
 prints its pre-existing `--out` unknown-argument notice and saves its default
 `screenshot.png`; this follow-up did not change that behavior.
+
+## Phase 7 W8 — deferred commitments (implementation spec)
+
+Drafted 2026-08-02 and grounded against branch
+`codex/phase7-w7-watching-async-reimport` at commit `8d8a361`. W0–W7 are
+implemented in the working tree (W7 is on this branch, not yet merged to
+master). This spec must be reviewed before implementation. Review amendments
+are appended here; implementation does not reinterpret an unsettled point
+from memory.
+
+### Scope and exit
+
+W8 is the deferred-commitments bucket: the four items that earlier phases
+explicitly pushed to Phase 7 because they were UI or needed the project model
+to exist first. Each is small, and they are independent. This spec decides
+which are worth building, which are worth deferring again, and which should be
+dropped.
+
+The combined exit is: a user can rebind a runtime input action through a UI
+panel and see the new binding take effect on the next Play; a user can rebind
+a script asset through a file dialog and the `assetId` is preserved; a user
+can see script declaration diagnostics in the content browser for `.lua`
+assets; and cursor-lock is bound to an input action so a runtime script can
+request it.
+
+Not in W8: the host-dispatch extraction (scheduled but unstarted — see
+boundary). W8 does not add new asset operations, new watcher capabilities, or
+new scene-schema versions.
+
+### Grounded findings at `8d8a361`
+
+| ID | Current fact | Consequence |
+|---|---|---|
+| W8-F1 | `InputConfig` provides `ParseInputContextRecords`, `ComposeInputContexts`, `InputContextRecordsToJson`, and `IsEditorOwnedInputContext` (`InputConfig.h:35-53`). Composition is deterministic: built-ins → project defaults → user overrides, with empty bindings as explicit unbind (`InputConfig.h:43-51`; `InputConfig.cpp:322-352`). | The data model is complete. W8's input rebinding UI is purely an authoring surface over `InputConfig`. The CPU-only composition, validation, and serialization already exist and are tested. |
+| W8-F2 | `InputService::ApplyConfiguration` (`InputService.cpp:180-231`) rebuilds all four owned contexts (`editor`, `viewport`, `viewport.look`, `runtime`) from composed records. It is called at project open (`WalnutApp.cpp:3258-3265,3303`), at standalone scene open (`:3200-3201`), and on input-settings save. | The runtime already consumes composed input. W8's rebinding UI calls `ApplyConfiguration` after editing overrides, exactly as the existing settings-save path does. No new runtime wiring is needed. |
+| W8-F3 | `EditorSettingsStore` owns `m_InputOverrides` (`EditorSettings.h:62-66,76`) and serializes them as `inputOverrides` in schema v3 (`EditorSettings.cpp:227-246`). The v2 → v3 migration drops editor-owned records and promotes runtime records (`EditorSettings.cpp:152-207`). | User overrides already persist. W8's rebinding UI edits `m_InputOverrides` and calls `Save`, reusing the existing persistence path. No new serialization is needed. |
+| W8-F4 | `IsEditorOwnedInputContext` returns true for `editor`, `viewport`, `viewport.look` (`InputConfig.cpp:194-198`). `ValidateScope` rejects project defaults for editor-owned contexts and restricts project v1 to the `runtime` context only (`InputConfig.cpp:136-155`). User overrides accept editor-owned contexts when explicitly authored in v3. | The rebinding UI must refuse to let the user rebind editor-owned contexts through the project defaults panel. It may allow rebinding editor-owned contexts through user overrides (the existing v3 contract), but this is a user preference, not a project-shippable binding. |
+| W8-F5 | The `runtime` context is populated by `LoadDefaults` with: `move_forward` (W/S), `move_right` (D/A), `move_up` (E/Q), `look` (right mouse), `jump` (Space), `primary_action` (F), plus gamepad axes (`InputService.cpp:161-178`). These are the bindings a user can rebind. | The rebinding UI lists the `runtime` context's mappings and lets the user edit each one's action bindings (keyboard, mouse, gamepad) or axis bindings. The built-in defaults are the starting point; the user's overrides replace specific mappings. |
+| W8-F6 | `InputTypes.h` defines `ActionBinding` (device, code, modifiers, gamepadSlot) and `AxisBinding` (device, code, positive, negative, gamepadSlot, deadZone, invert) (`InputTypes.h:177-230`). `InputMapping` holds a name, an `isAxis` flag, and vectors of action/axis bindings. | The rebinding UI must capture a new `InputMapping` for the action being rebound. For an action mapping, the user presses a key / mouse button / gamepad button; for an axis mapping, the user provides positive/negative keys or a gamepad axis. The UI does not need to support modifier combinations initially — a single key press is the common case. |
+| W8-F7 | The script inspector (`SceneEditorUI::RenderScriptEditor`, `SceneEditorUI.cpp:1765-1812`) edits the script asset path as a raw `InputText` with `EnterReturnsTrue`. On Enter or `DeactivatedAfterEdit`, it builds a before/after `ScriptComponent` and calls `SetScriptState` (`:1784-1796`). The path is the only field edited — `assetId` and `sourceKey` are not touched by the path edit. | The "Rebind" button is a file-dialog replacement for the raw `InputText`. It opens a file dialog filtered to `.lua`, sets the path, and submits the same `SetScriptState` command. The `assetId` is preserved because `SetScriptState` calls `NormalizeAndValidateScriptComponent` (`SceneManager.cpp:3826-3829`), which derives `sourceKey` from `path` but does not touch `assetId` (`ScriptComponentValidation.h:48`). |
+| W8-F8 | `NormalizeAndValidateScriptComponent` (`ScriptComponentValidation.h:17-113`) sets `output.asset.sourceKey = "lua:asset=" + output.asset.path` when the path is non-empty (`:48`). It does not modify `assetId`. `ScriptComponentCanonicalEqual` (`:123-136`) compares `assetId`, `kind`, `path`, `sourceKey`, and `fieldValues`. | A script rebind changes `path` and `sourceKey` but preserves `assetId`. This is the W5 identity contract: the sidecar is the source of truth, and `assetId` is a cache of it. Rebinding does not mint identity. If the new path points to a different physical file with a different sidecar, the resolver will report a `Conflict` on next resolve (`AssetResolver.h:52-53`). |
+| W8-F9 | The content browser panel (`WalnutApp.cpp:1228-1460`) lists `AssetRecord` entries from the database snapshot. It shows source path, supports search, and has context-menu items for rename/move/delete/reimport. It does not display any declaration or field information for `.lua` assets. | Declaration diagnostics for `.lua` assets can be surfaced in the content browser by querying `ScriptFieldRegistry::GetDeclaredFields` for each `.lua` record and displaying the parse status (parsed/failed) and diagnostic message. The registry is already injected into `WalnutApp` (`m_InspectorFieldRegistry`, `WalnutApp.cpp:172`). |
+| W8-F10 | `ScriptFieldRegistry::GetDeclaredFields` (`ScriptFieldRegistry.h:77-84`) returns a `Result` with `descriptors`, `parsed` (bool), and `diagnostic` (string). It caches by path and invalidates on mtime/size/hash change. A missing file yields `parsed=false`; an empty file is legal (`parsed=true`, zero descriptors). | The content browser can call `GetDeclaredFields` for each `.lua` asset record and display a status icon: green (parsed), red (parse failed + diagnostic), grey (missing file). The cache means repeated browser frames do not re-parse. |
+| W8-F11 | `FieldDiagnostic` (`ScriptFieldReconcile.h:14-38`) has 13 kinds covering field-level reconciliation issues (Added, Removed, Renamed, TypeChanged, ParseFailed, etc.). `ScriptFieldResolver` (`ScriptFieldResolver.cpp:19-122`) produces field diagnostics during scene load. These are load-time diagnostics, not browser-time diagnostics. | The content browser's declaration diagnostics are simpler than `FieldDiagnostic`: they are per-asset (does this `.lua` file parse?), not per-field. The browser displays the `ScriptFieldRegistry::Result.diagnostic` string, not individual `FieldDiagnostic` entries. Per-field diagnostics remain in the inspector, where they already exist (`SceneEditorUI.cpp:1837-1841`). |
+| W8-F12 | `IInputService::RequestCursorCapture(bool)` (`InputTypes.h:273-277`) is the cursor-lock API. `InputService::EndFrame` applies it via `Walnut::Input::SetCursorMode` (`InputService.cpp:320-336`). `Camera::OnUpdate` calls `RequestCursorCapture(true)` when the `look` action is held and `false` otherwise (`Camera.cpp:58,63`). | Cursor lock is already wired for the editor camera. The deferred commitment ("cursor-lock binding") is about making it available to runtime scripts, not about adding the mechanism. The `look` action in the `runtime` context already triggers cursor lock through the same `RequestCursorCapture` path — `Camera::OnUpdate` is editor-only, but a runtime script calling `input.request_cursor_capture(true)` would need the same API exposed to Lua. |
+| W8-F13 | `ScriptSystem` stores `const IInputService*` (`ScriptSystem.h:117`), and `IInputService::RequestCursorCapture` is non-const (`InputTypes.h:276`). Phase 6C W3 explicitly deferred cursor capture: "6C does NOT widen the pointer — cursor capture is out of scope" (`:5975-5980`). | The cursor-lock binding requires widening `ScriptSystem`'s pointer from `const IInputService*` to `IInputService*`, or providing a separate non-const cursor-capture callback. This is a small interface change with test implications: `ScriptSystem` is constructed with `const IInputService*` in production (`ScriptSystem.h:117`). |
+| W8-F14 | `RuntimeSceneController` pushes the `runtime` context on Play (`WalnutApp.cpp:3041`) and pops it on Stop. The runtime context contains the `look` action (right mouse, `InputService.cpp:167`). During Play, the editor camera is not updated; the runtime scene's camera entity is used instead. | The cursor-lock binding for runtime is: expose `RequestCursorCapture` to Lua so a runtime script can lock the cursor for mouse-look, matching what the editor camera already does. The `look` action binding already exists in the runtime context. |
+| W8-F15 | No input rebinding UI exists in `WalnutApp.cpp` or `SceneEditorUI.cpp`. The Session panel shows project status and `lastBrowseDirectory` (`WalnutApp.cpp:1078-1124`). There is no "Input" or "Bindings" panel. The View menu lists Camera, Performance, Render Settings, Scene, Session, Content Browser, Outliner, Inspector (`:4170-4177`). | W8 adds a new "Input Bindings" panel, following the existing pattern: `m_ShowInputBindingsWindow`, a `DrawInputBindingsPanel()` method, a View-menu item. |
+| W8-F16 | `RT2Tests` compiles zero `RT2App/src` files. It includes `InputConfig.h`, `ScriptFieldReconcile.h`, `ScriptComponentValidation.h`, `AssetWatchPolicy.h`, `ContentBrowserOperations.h`, and other CPU-only headers, but never `WalnutApp.cpp`, `SceneEditorUI.cpp`, or `InputService.cpp`. | All W8 UI logic is untestable by construction. CPU-only logic must be pushed into modules to be testable. The host-dispatch extraction (scheduled but unstarted) would make host wiring testable; until it lands, W8's testable surface is limited to the CPU-only modules. |
+
+### Recovered deferred commitments
+
+All four items were found in the Phase 7 commitments table (`:6379-6390`)
+and re-tracked through the W4/W5, W6, and W7 specs. None has been silently
+implemented.
+
+| Source | Commitment | W8 treatment |
+|---|---|---|
+| `:3311,3380` | Input rebinding dialog. | **Build.** The data model (W4) and composition (W4) are complete. W8 adds the authoring UI. |
+| `:4142` | Script asset Rebind button. | **Build.** The `InputText` path edit exists (`SceneEditorUI.cpp:1781`). W8 adds a "Browse…" button that opens a file dialog. |
+| `:5600` | Declaration diagnostics in content browser. | **Build.** The content browser exists (W6). `ScriptFieldRegistry` exists. W8 connects them. |
+| `:5980` | Cursor-lock binding. | **Defer again.** See D-W8-4. The mechanism exists (`RequestCursorCapture`), but exposing it to Lua requires widening `ScriptSystem`'s pointer, which is an interface change with test implications that should land separately. |
+
+### Decisions — answered before code
+
+These are the settled answers for this spec. Review may amend them before
+implementation; implementation does not choose a different answer locally.
+
+#### D-W8-1 — input rebinding UI edits user overrides, not project defaults
+
+**Decision:** the rebinding UI edits `EditorSettingsStore::m_InputOverrides`
+(`EditorSettings.h:62-66`). It does not edit project `inputContexts` — those
+are authored in the `.rt2proj` file by hand or by a future project-settings
+editor. The UI lists the composed result (built-ins + project + user) so the
+user sees the effective bindings, but edits only the user override layer.
+
+The UI lists the `runtime` context's mappings by default, since that is what
+a gameplay author rebinds. Editor-owned contexts (`editor`, `viewport`,
+`viewport.look`) are shown in a separate read-only section with a note that
+they can be overridden in the settings file but not through the project. This
+matches the W4 contract: project defaults may not target editor-owned contexts
+(`InputConfig.cpp:142-145`), and the v2 → v3 migration drops inert editor
+records (`EditorSettings.cpp:167`).
+
+Rebinding a mapping captures a new `InputMapping` and writes it to
+`m_InputOverrides`. An empty binding (no actions, no axes) is an explicit
+unbind that removes the inherited mapping (`InputConfig.cpp:182-184`). The UI
+supports both "rebind to a new key" and "unbind" actions. After editing, the
+UI calls `ApplyConfiguration` and `Save`, reusing the existing path.
+
+**What a user can rebind:** any `runtime` mapping's action bindings (keyboard
+key, mouse button, gamepad button) or axis bindings (keyboard pair, gamepad
+axis). **What is refused:** editing project `inputContexts` through this UI
+(not an override), and editing editor-owned contexts through project defaults
+(rejected by `ValidateScope`).
+
+**How a conflicting assignment is shown:** if the user binds the same key to
+two actions in the same context, the UI shows a warning but does not prevent
+it — the input system resolves disjunctively (any binding firing fires the
+action), so two actions on the same key both fire. This is documented
+behaviour, not a defect.
+
+#### D-W8-2 — script Rebind button is a file dialog, not a path mint
+
+**Decision:** the Rebind button opens a file dialog filtered to `.lua` files,
+rooted at the active `assetRoot` (or `lastBrowseDirectory` in standalone
+mode). On selection, it sets `ScriptComponent::asset.path` to the
+asset-root-relative path and calls `SetScriptState`, exactly as the existing
+`InputText` path edit does (`SceneEditorUI.cpp:1784-1796`).
+
+The button does **not** touch `assetId`. `NormalizeAndValidateScriptComponent`
+derives `sourceKey` from `path` but preserves `assetId`
+(`ScriptComponentValidation.h:48`). This is the W5 identity contract: the
+sidecar is the source of truth, and `assetId` is a cache of it. Rebinding
+does not mint identity.
+
+If the new path points to a different physical file with a different sidecar,
+the resolver will report a `Conflict` on next resolve
+(`AssetResolver.h:52-53`). This is correct behaviour: the user changed the
+script asset, and if the new asset has a different identity, the scene's
+`assetId` is stale and needs migration. The Rebind button does not silently
+fix this; it surfaces the diagnostic.
+
+The Rebind button replaces the `InputText` for the path field. The
+`InputText` is retained as a fallback for manual path entry, but the primary
+interaction is the file dialog. The button label is "Browse…" to match the
+existing `lastBrowseDirectory` dialog pattern (`WalnutApp.cpp:1111`).
+
+#### D-W8-3 — declaration diagnostics in the content browser use ScriptFieldRegistry
+
+**Decision:** the content browser queries `ScriptFieldRegistry::GetDeclaredFields`
+for each `.lua` asset record and displays a status indicator beside the
+asset's source path:
+
+- **Green dot:** `parsed == true` — the script parses cleanly.
+- **Red dot:** `parsed == false` — the script failed to parse. The
+  `diagnostic` string is shown in a tooltip on hover.
+- **Grey dot:** the file is missing or unreadable. `GetDeclaredFields` returns
+  `parsed == false` with a "failed to read script file" diagnostic
+  (`ScriptFieldRegistry.cpp:391`).
+
+The query is per-frame for visible records only (not the entire database).
+The registry's cache (`ScriptFieldRegistry.h:77-84`) means repeated frames do
+not re-parse. The cache invalidates on mtime/size/hash change, so a W7
+watcher-triggered refresh after an external `.lua` edit automatically
+re-parses on the next frame.
+
+The source of truth for declaration diagnostics is `ScriptFieldRegistry`, not
+`FieldDiagnostic`. Per-field diagnostics (Added, Removed, TypeChanged, etc.)
+remain in the inspector, where they already exist
+(`SceneEditorUI.cpp:1837-1841`). The browser shows only the per-asset parse
+status, not per-field reconciliation.
+
+This is a read-only display. The browser does not edit declarations or field
+values. Editing remains in the inspector.
+
+#### D-W8-4 — cursor-lock binding is deferred again
+
+**Decision:** the cursor-lock binding is deferred to a follow-up task, not
+included in W8.
+
+**Rationale:** the mechanism exists (`RequestCursorCapture`,
+`InputService.cpp:320-336`). The editor camera already uses it
+(`Camera.cpp:58,63`). But the deferred commitment was about making it
+available to **runtime scripts**, which requires widening `ScriptSystem`'s
+pointer from `const IInputService*` to `IInputService*`
+(`ScriptSystem.h:117`; `InputTypes.h:276`). Phase 6C W3 explicitly deferred
+this: "6C does NOT widen the pointer — cursor capture is out of scope"
+(`:5975-5980`).
+
+Widening the pointer is a small interface change, but it has test
+implications: `ScriptSystem` is constructed with `const IInputService*` in
+production, and the test harness would need a non-const mock. It also
+requires a Lua binding (`input.request_cursor_capture(bool)`) and a runtime
+acceptance exercise. This is more than a UI button — it is a runtime API
+addition that touches the script system, the input system, and the Lua
+binding layer.
+
+Given that W8 is the last Phase 7 workstream and the other three items are
+purely UI, mixing in a runtime API change changes the character of the
+workstream. The cursor-lock binding should land as a named follow-up task
+("cursor-lock runtime binding") rather than being squeezed into the
+deferred-UI bucket.
+
+**Carry-forward:** P7-R2: when a later phase introduces cursor-lock binding
+for runtime scripts, it must widen `ScriptSystem`'s `IInputService` pointer
+to non-const, add the Lua binding, and provide a runtime acceptance exercise
+that verifies mouse-look during Play. It must not add a second cursor-capture
+mechanism parallel to `RequestCursorCapture`.
+
+#### D-W8-5 — CPU-only `InputBindingEditor` module for rebind logic
+
+**Decision:** the rebinding logic — capturing a key press into an
+`InputMapping`, validating it against `ValidateScope`, building the override
+record, and composing the result — lives in a new CPU-only module
+(`InputBindingEditor.{h,cpp}`) beside `InputConfig`. It provides:
+
+- `CaptureActionBinding(device, code, modifiers, gamepadSlot)` →
+  `ActionBinding`.
+- `CaptureAxisBinding(device, code, positive, negative, gamepadSlot, deadZone,
+  invert)` → `AxisBinding`.
+- `BuildOverrideRecord(contextId, mappingName, isAxis, bindings)` →
+  `InputContextRecord`.
+- `DescribeMapping(const InputMapping&)` → human-readable string (e.g.
+  "W (Keyboard)", "Right Mouse", "Gamepad A").
+- `FindConflicts(const std::vector<InputContextRecord>&)` → list of
+  same-context mappings sharing a binding.
+
+The ImGui panel (`DrawInputBindingsPanel`) lives in `WalnutApp.cpp` and calls
+the CPU-only module through callbacks, following the `ContentBrowserOperations`
+precedent from W6.
+
+### Test-provable properties vs interactive acceptance
+
+This section is required because W8 is almost entirely UI, and the host
+wiring is not testable (W8-F16). The distinction is stated explicitly rather
+than presenting a predicate test as evidence that a feature works.
+
+#### Test-provable (CPU-only modules, RT2Tests)
+
+| Property | How it is proven |
+|---|---|
+| `BuildOverrideRecord` produces a valid `InputContextRecord` that passes `ParseInputContextRecords` with `UserOverrides` scope. | Unit test: build a record, round-trip through JSON, parse, assert equality. |
+| `ComposeInputContexts` with the new override produces the expected composed mapping (override wins over built-in). | Unit test: compose built-ins + override, assert the overridden mapping's bindings match. |
+| An explicit unbind (empty bindings) removes the inherited mapping from the composed result. | Unit test: compose built-ins + unbind override, assert the mapping is absent. |
+| `FindConflicts` detects two mappings in the same context sharing a binding. | Unit test: two mappings with the same key, assert conflict is reported. |
+| `DescribeMapping` produces the expected string for each device kind. | Unit test: keyboard, mouse, gamepad button, gamepad axis. |
+| Script rebind preserves `assetId`: `NormalizeAndValidateScriptComponent` with a new path but old `assetId` leaves `assetId` unchanged. | Unit test: construct a `ScriptComponent` with a non-nil `assetId`, change `path`, normalize, assert `assetId` is unchanged. |
+| Script rebind derives `sourceKey` from the new path: `"lua:asset=" + newPath`. | Unit test: same setup, assert `sourceKey` matches. |
+
+#### Interactive acceptance only (WalnutApp/SceneEditorUI, not testable)
+
+| Property | Acceptance exercise | Observable pass condition |
+|---|---|---|
+| The Input Bindings panel opens, lists runtime mappings, and lets the user rebind one. | Open the panel, rebind `move_forward` from W to Up arrow, enter Play. | The entity moves with Up arrow, not W. |
+| The rebinding takes effect on the next Play without restarting. | Rebind, enter Play, verify, Stop, rebind back, enter Play again. | The second Play uses the restored binding. |
+| The script Rebind button opens a file dialog and sets the path. | Select a scripted entity, click "Browse…", pick a different `.lua` file. | The inspector shows the new path; the field registry updates; on Play the new script runs. |
+| The script `assetId` is preserved after rebind. | Rebind a script, save, reopen the scene. | The `assetId` in the reopened scene matches the pre-rebind `assetId` (verified by diagnostic output or by the resolver not reporting a Conflict). |
+| Declaration diagnostics appear in the content browser for `.lua` assets. | Open the content browser, observe a `.lua` asset with a syntax error. | A red dot appears beside the asset; hovering shows the parse error message. |
+| Declaration diagnostics update after external edit (W7 watcher). | With the browser open, externally edit a `.lua` file to introduce a syntax error. | The dot turns red within the W7 refresh window (100 ms debounce + refresh). |
+| The Input Bindings panel shows editor-owned contexts as read-only. | Open the panel, observe the editor/viewport section. | The editor/viewport mappings are displayed but not editable; a note says they can be overridden in the settings file. |
+| The unbind action removes a mapping. | Select a runtime mapping, click "Unbind". | The mapping disappears from the composed list; on Play, that action does nothing. |
+
+### Implementation order
+
+Each step keeps `RT2Tests` and `RT2SliceRunner` CPU-only and ends with
+focused tests or interactive acceptance before the next step.
+
+1. **W8.0 — CPU-only `InputBindingEditor` module.** Add
+   `InputBindingEditor.{h,cpp}` with: `BuildOverrideRecord`,
+   `CaptureActionBinding`, `CaptureAxisBinding`, `DescribeMapping`,
+   `FindConflicts`. No ImGui, no Walnut. Focused tests: override record
+   round-trip, composition with override, explicit unbind, conflict
+   detection, describe-mapping for all device kinds, script-rebind
+   `assetId` preservation.
+
+2. **W8.1 — Input Bindings panel.** Add `DrawInputBindingsPanel()` to
+   `WalnutApp`, register `m_ShowInputBindingsWindow`, add View-menu item.
+   Display the composed runtime mappings. Wire "Rebind" to a key-capture
+   modal (press any key). Wire "Unbind". On edit, call `ApplyConfiguration`
+   and `Save`. Interactive acceptance: rebind `move_forward`, enter Play,
+   verify.
+
+3. **W8.2 — Script Rebind button.** Add a "Browse…" button beside the
+   script path `InputText` in `RenderScriptEditor`. On click, open a file
+   dialog filtered to `.lua`, rooted at the active `assetRoot`. On
+   selection, build the after-state with the new path (same `assetId`),
+   call `SetScriptState`. Interactive acceptance: rebind a script, save,
+   reopen, verify `assetId` is preserved.
+
+4. **W8.3 — Declaration diagnostics in content browser.** Extend
+   `DrawContentBrowserPanel` to query `ScriptFieldRegistry::GetDeclaredFields`
+   for visible `.lua` records and display a status dot. Tooltip shows the
+   diagnostic on hover. Interactive acceptance: observe green/red/grey dots
+   for valid/invalid/missing scripts; externally edit a `.lua` file and
+   verify the dot updates.
+
+### Permanent tests and discrimination proofs
+
+| Permanent evidence | Temporary fault that must make it fail |
+|---|---|
+| `BuildOverrideRecord` produces a record that round-trips through `InputContextRecordsToJson` → `ParseInputContextRecords(UserOverrides)` and matches the input. | Omit the `contextId` from the record; the test must fail because `ParseInputContextRecords` rejects a missing contextId. |
+| `ComposeInputContexts` with a user override for `runtime.move_forward` produces a composed mapping whose bindings match the override, not the built-in. | Swap the overlay order (user before built-in); the test must fail because the built-in wins. |
+| An explicit unbind (empty bindings in the override) removes `runtime.move_forward` from the composed result. | Treat empty bindings as "inherit" instead of "unbind"; the test must fail because the built-in mapping survives. |
+| `FindConflicts` reports two `runtime` mappings that share the same keyboard code. | Compare only within the same mapping name instead of the same context; the test must fail because the conflict is missed. |
+| `DescribeMapping` returns "W (Keyboard)" for `KeyCode::W` on `KeyboardKey`, "Right Mouse" for `MouseButton::Button1` on `MouseButton`, "Gamepad A" for `GamepadButton::A` on `GamepadButton`. | Return the numeric code as a string; the test must fail because the description is not human-readable. |
+| `NormalizeAndValidateScriptComponent` with a new `path` but old `assetId` leaves `assetId` unchanged and sets `sourceKey = "lua:asset=" + newPath`. | Clear `assetId` when `path` changes; the test must fail because identity was destroyed. |
+
+Every new permanent test gets its discrimination fault exercised before the
+implementation report calls it protective. Interactive acceptance exercises
+are first-class deliverables and must be completed and recorded before the
+implementation report claims W8 is done. The final gate builds the Release
+and Debug solutions, runs `RT2Tests.exe` from the repository root, runs the
+scripting regression gate and both project/standalone slice-runner scenarios,
+and records the actual counts measured then. No count is copied from an older
+completed phase.
+
+### Review checklist and boundary
+
+A reviewer must verify at least: the override-only editing contract (D-W8-1)
+and that project defaults are not editable through the UI; the identity
+preservation contract (D-W8-2) verified against
+`NormalizeAndValidateScriptComponent`; the declaration-diagnostics source
+(D-W8-3) is `ScriptFieldRegistry`, not `FieldDiagnostic`; the cursor-lock
+deferral (D-W8-4) and its carry-forward note; the CPU-only module (D-W8-5)
+and its testability; the test-provable vs interactive-acceptance split; and
+all interactive acceptance exercises. Any accepted correction is appended as
+a dated review amendment.
+
+W8 does not add the host-dispatch extraction (scheduled but unstarted). W8
+does not add cursor-lock runtime binding (deferred again as P7-R2). W8 does
+not edit project `inputContexts` through the UI (override-only). W8 does not
+add per-field diagnostics to the content browser (those remain in the
+inspector). W8 does not add new asset operations, new watcher capabilities, or
+new scene-schema versions.
+
+**Materially safer if the host-dispatch extraction landed first.** W8 is the
+third workstream in a row (after W6 and W7) where the host wiring is not
+testable. The W6 rename/move/delete modals had an ImGui ID-stack bug that
+left them non-functional while CPU tests were green; the W7 suppression
+ordering was proven but the host's call-site routing was not. If the
+host-dispatch extraction landed before W8, the Input Bindings panel's call to
+`ApplyConfiguration` and `Save`, the Rebind button's call to `SetScriptState`,
+and the browser's call to `GetDeclaredFields` would all be testable host
+wiring. This is a genuine input to sequencing: the extraction is not blocking
+W8, but it would materially reduce the risk of another green-tests-broken-UI
+
+#### Review amendment W8-A1 (2026-08-02) — commitment citations corrected
+
+The commitments table originally cited `:3311,3380`, `:4064,5274,4142`,
+`:5521,5600` and `:5901,5980`. Five of those nine line numbers pointed at
+unrelated content — `:4064` at a recovery-test result, `:5274` at command
+sync-impact, `:5521` at a blank line, `:5901` at LuaPanic hardening.
+
+The cause is worth recording, because it defeats an assumption this document
+relies on. The numbers were inherited from the W4/W5 spec's own commitments
+table, where they were correct when written. **Append-only does not guarantee
+stable line numbers**: two earlier edits — the navigation-table addition in the
+preamble and the Phase 8 heading correction — inserted lines *above* them and
+shifted everything below by roughly twenty-five lines.
+
+Corrected to the verified locations: input rebinding at `:3389-3390` and
+`:3458-3459`, the script Rebind button at `:4142`, declaration diagnostics at
+`:5600`, cursor-lock at `:5980`. Each was located by content, not by
+arithmetic.
+
+The rule that follows: a citation copied from an earlier section is a claim
+about the current file and must be re-verified like any other, exactly as
+AGENTS.md already requires for counts and status claims. The commitments
+themselves were all real and correctly identified; only the coordinates drifted.


### PR DESCRIPTION
Completes Phase 7 W7 and fixes three W6 defects that a green test suite could
not see. Also lands the W8 spec.

## W7 — watching and async reimport

Widens the efsw watcher from script directories to the project asset root and
fixes the watch set only being rebuilt on scene open. Event classification,
coalescing, debounce, overflow and missed-event handling live in a CPU-only
`AssetWatchPolicy` module.

Per **W7-A1**, only `.lua` scripts auto-reload; models, textures and
environments trigger a database refresh only. This knowingly substitutes Phase
7's stated runtime acceptance — a texture live on the GPU is not safe to swap
from a watcher thread.

Per **W7-A2**, suppression entries clear one drain cycle after the refresh, so
late asynchronous filesystem events from a W6 operation are still suppressed.

Threading: classification happens outside the lock, the critical section covers
only suppression-check and enqueue, and listener/watcher declaration order
guarantees the listener outlives efsw's thread.

## Three W6 defects, all found by interactive acceptance

The pattern is the point. In each case the CPU operations were fully
unit-tested and green while the feature was broken or unreachable in the app.

1. **Rename, Move and Delete modals never opened.** `OpenPopup` was called
   inside both a per-record `PushID` and `BeginPopupContextItem`, while the
   matching `BeginPopupModal` sat outside both — two stacked ID mismatches. The
   content browser's three headline operations were unreachable.
2. **The delete confirmation clipped its dependants list**, hiding the only
   information the user gets before a destructive delete.
3. **The dependants query reported nothing for unmigrated scenes.** The path
   fallback was gated on the *record* having no asset ID, but the scanner never
   emits such a record — so matching was ID-only, and any v3 scene whose
   references lack IDs showed zero dependants for an asset it genuinely used.

The third is the serious one: `ContentBrowserDeleteAllowed` ignores the
dependant count, so the list is the sole mechanism informing the confirmation.

## Evidence

All twelve W7 discrimination proofs recorded with actual red output, and four
new dependants tests with theirs. One negative-case test is honestly recorded
as non-discriminating against a revert rather than given a manufactured fault.

All three suppression acceptances now pass interactively — rename, move and
delete each complete with **no redundant refresh**. That is the only end-to-end
evidence the registry works against real efsw timing; every unit test uses an
injected callback.

Release and Debug: **736/736 cases, 146,453 assertions**. Script, slice and
punctual light gates pass. `--validate` exits 0 with zero validation messages.

## Known gap, recorded not hidden

`RT2Tests` compiles no RT2App sources, so host wiring cannot be tested.
Commenting out a suppression registration leaves the suite green. The same gap
covers W5's recovery gate and W6's operation predicates, and this PR contains
three concrete failures caused by it. Extracting the host dispatch out of
`WalnutApp.cpp` is scheduled separately and closes all three at once.

## Also included

The W8 spec (deferred commitments), with amendment W8-A1 correcting five stale
line citations that drifted when earlier edits inserted content above them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)